### PR TITLE
chore: 对齐 dsh 0.1.0-rc.8，并给上游接口变动加一道护栏

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 本文件记录对使用者可见的变化。版本遵循语义化版本。
 
+## 0.2.1 — 2026-08-20
+
+对齐 dsh 0.1.0-rc.8，并给上游接口变动加一道护栏。
+
+### 兼容性
+
+- 对着 rc.8 逐条核对了本插件用到的每一个上游面：`ctx.commands.register` 的注册契约、
+  `ctx.apiProxy` 的服务键与成员、十二个 RPC 方法的签名、goal 服务、compaction 检查点
+  标记、preset 组装、`dsh plugin add` 的装载机制。**没有一处发生变化**，rc.6 / rc.7 /
+  rc.8 上行为一致。
+- rc.8 给命令注册表加了图片附件：`CommandInvocation` 多了 `attachments` 字段，
+  `CommandInputDescriptor` 多了可选的 `images`。这是增量改动。`/bridge` 不声明
+  `input.images`，所以带图片的调用会被注册表在进入处理器之前挡下并给出明确错误——
+  这正是我们想要的行为，不需要改代码。类型里把 `attachments` 显式声明了出来。
+
+### 新增
+
+- **`/bridge --doctor`**：报出这套 host 实际暴露了十二个网关方法里的哪几个、
+  当前模式、可迁入模式、生效配置。上游哪天挪了东西，它会点名说缺了什么，
+  而不是让用户遇到一个含糊的失败。
+- **`test/upstream-contract.test.mjs`**：把依赖的上游面钉成测试——方法名集合是冻结的，
+  命令定义形状按上游 `normalizeDefinition` 的要求断言，并验证处理器容忍上游后加的字段
+  （rc.8 的 `attachments` 就是这么加进来的）。dsh 是 developer preview，
+  这道护栏让 CI 先发现问题，而不是用户先发现。
+
+### 移除
+
+- `@deepseek-ai/dsh-skill` 依赖（peer + dev）。0.2.0 删掉技能之后就没有任何代码
+  import 它了，留着只会在安装时产生无意义的 peer 噪音。
+
 ## 0.2.0 — 2026-08-18
 
 这一版的主题是：**让它成为一个正常的 dsh 插件**——`dsh plugin add` 装上、重启，

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@
   （rc.8 的 `attachments` 就是这么加进来的）。dsh 是 developer preview，
   这道护栏让 CI 先发现问题，而不是用户先发现。
 
+### 文档
+
+- README（中英）新增一节「那 rc.8 的 `@` 引用会话呢？」。rc.8 的 web bundle 默认挂上了
+  `dsh-session-reference` 与 `@` 输入触发，读者会问这个问题：`@` 是把另一个会话历史的
+  有界只读快照**加**到当前会话上，bridge 是把会话压缩成固定 schema **搬**到目标 preset
+  的新会话去。而且被引用的历史是旧 preset 下产生的（含工具调用），正是跨 preset 交接
+  最想丢掉的部分。
+
 ### 移除
 
 - `@deepseek-ai/dsh-skill` 依赖（peer + dev）。0.2.0 删掉技能之后就没有任何代码

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![ci](https://github.com/Totoro-qaq/dsh-plugin-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/Totoro-qaq/dsh-plugin-bridge/actions/workflows/ci.yml)
 [![license](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![node ≥22](https://img.shields.io/badge/node-%E2%89%A522-339933)](package.json)
-[![dsh 0.1.0-rc.6 · rc.7](https://img.shields.io/badge/dsh-0.1.0--rc.6%20%C2%B7%20rc.7-4c8dff)](https://github.com/deepseek-ai/deepseek-harness)
+[![dsh 0.1.0-rc.6 · rc.7 · rc.8](https://img.shields.io/badge/dsh-rc.6%20%C2%B7%20rc.7%20%C2%B7%20rc.8-4c8dff)](https://github.com/deepseek-ai/deepseek-harness)
 [![presets](https://img.shields.io/badge/presets-standard%20%C2%B7%20code%20%C2%B7%20minimal%20%C2%B7%20cordis-4c8dff)](https://github.com/deepseek-ai/deepseek-harness)
 
 English | [中文](README.zh.md)
@@ -162,9 +162,21 @@ The result splits cleanly by whether the target preset has tools, and averaging 
 ## Testing & verification
 
 - `npm test` runs **95 tests**: compression behaviour (including *semantic* budget assertions — "when material is clipped, is the newest still there?"), the session-event folder, summary-schema contracts, **the `/bridge` command end-to-end**, the in-process `ctx.apiProxy` adapter, the full migration pipeline against a fake dsh host, and the CLI end-to-end (real process, real HTTP gateway, real wire envelope). None of it needs a live host or spends a token.
+- `test/upstream-contract.test.mjs` pins the narrow upstream surface this plugin stands on — the twelve RPC method names, the command-definition shape, and tolerance for fields upstream adds later (rc.8's `attachments` landed exactly this way). dsh is a developer preview whose README promises breaking changes; this is the guard that makes CI notice before users do.
 - `npm test` also typechecks `src/` **and** `eval/` — the evaluation harness imports the same modules the command does, so it cannot drift from the product path.
 - CI additionally checks: `lib/` is in sync with `src/`, datasets parse, `npm pack` contents are complete, on Node 22 and 24.
 - ⚠️ **Not yet verified against a live host.** Every RPC signature, the command-dispatch contract, and the `ctx.apiProxy` service shape were checked against upstream source, and the fake host implements that contract — but no one has yet typed `/bridge` into a running `dsh web`. Do that first; `dsh-bridge doctor` covers the same assumptions from the CLI side.
+
+## dsh compatibility
+
+Verified against **0.1.0-rc.6, rc.7 and rc.8** — the surfaces this plugin uses (`ctx.commands.register`, `ctx.apiProxy`, twelve RPC methods, the goal service, the compaction checkpoint marker) are identical across all three. rc.8's command-registry change (image attachments on invocations) is additive and does not affect `/bridge`, which declares no `input.images` and is therefore protected by the registry's own rejection path.
+
+If a future release does move something, `/bridge --doctor` names the missing method instead of failing vaguely:
+
+```
+网关：进程内 ctx.apiProxy · 10/12 个方法可用
+⚠ 缺少：session.rename, goal.create
+```
 
 ## Configuration
 
@@ -186,7 +198,7 @@ Set through the profile's `cordis.patch.yml`, or the `DSH_BRIDGE_*` environment 
 ## Known limitations and deferred work
 
 - **`/bridge <preset>` blocks while the compression worker runs** (typically 20–60s; capped by `previewTimeoutMs`). A command result is synchronous, so a very slow worker can outlast the client's RPC timeout — the migration engine is unaffected, and the CLI path has no such ceiling.
-- **Requires `commands` and `apiProxy`.** Both are in the official `web` profile (base mounts the command registry, the web bundle mounts the API gateway). In a profile without them the plugin pends rather than half-mounting — loud, not silent.
+- **Requires `commands` and `apiProxy`.** Both are in the official `web` profile (base mounts the command registry, the web bundle mounts the API gateway). In a profile without them the plugin pends rather than half-mounting — loud, not silent. `/bridge --doctor` reports which of the twelve gateway methods this host actually exposes.
 - **The compression worker cannot reuse the original session's KV cache.** Upstream's own compaction backend replays the conversation prefix precisely so the auxiliary call is a real prefix of the last routed request; this plugin instead spins a separate worker session, whose prefix is unrelated. The measured cache hits are cross-run repetition of the instruction, not warm-prefix reuse. Doing this properly means calling `ctx.llm.stream()` in-process — deferred.
 - **The material still double-counts what a compaction already summarized.** `session.history` reads the log, so both the checkpoint and the user messages it replaced are collected.
 - **Structured output would be better than a markdown contract.** `ctx.subagents` supports a JSON schema per child (plus model, persona, and tool restriction), which would make "five sections" a type guarantee rather than a measured property. Deferred to keep this version verifiable against the shipped rc.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,16 @@ The result splits cleanly by whether the target preset has tools, and averaging 
 
 ⚠️ **This A/B has two known weaknesses, both fixed for future runs but not re-measured yet.** The 2026-08-17 runs shared one workspace, which is exactly how the control arm could scavenge from disk; every run now gets an empty temp workspace. And with n = 4 pairs the comparison is directional, not conclusive. See [docs/benchmark.md](docs/benchmark.md) §10.
 
+### What about `@`-referencing the old session? (new in rc.8)
+
+rc.8's web bundle mounts [`dsh-session-reference`](https://github.com/deepseek-ai/deepseek-harness/tree/master/packages/context/session-reference) and the `@` input trigger, so you can now pull another session into the current one as a mention. It is a genuinely useful feature, and it answers a different question than this plugin does.
+
+`@` **adds**: it attaches a bounded, read-only snapshot of another session's history to the session you are already in. Bridge **moves**: it compresses a session into a fixed five-section schema and hands that to a new session under a different preset, leaving the original alone.
+
+The difference bites in exactly the case this plugin exists for. The history you would reference was produced under the *old* preset — tool calls included — which is precisely what a cross-preset handoff wants to drop ("move state, not traces"), and it arrives as raw transcript rather than as goal / state / decisions / files / next step.
+
+Rule of thumb: pulling one fact out of an old session → `@`. Continuing the work under a different preset → `/bridge`.
+
 ## Testing & verification
 
 - `npm test` runs **95 tests**: compression behaviour (including *semantic* budget assertions — "when material is clipped, is the newest still there?"), the session-event folder, summary-schema contracts, **the `/bridge` command end-to-end**, the in-process `ctx.apiProxy` adapter, the full migration pipeline against a fake dsh host, and the CLI end-to-end (real process, real HTTP gateway, real wire envelope). None of it needs a live host or spends a token.

--- a/README.zh.md
+++ b/README.zh.md
@@ -161,6 +161,17 @@ dsh-bridge migrate --to code --summary-file <path>
 
 ⚠️ **这组 A/B 有两个已知弱点，都已修复但尚未重测。** 2026-08-17 那批 run 共用一个工作区——这正是对照臂能从磁盘上翻出事实的原因；现在每个 run 都用一个空的临时工作区。另外 n = 4 对只够给方向，不够给结论。见 [docs/benchmark.md](docs/benchmark.md) §10。
 
+### 那 rc.8 的 `@` 引用会话呢？
+
+rc.8 的 web bundle 挂上了 [`dsh-session-reference`](https://github.com/deepseek-ai/deepseek-harness/tree/master/packages/context/session-reference) 和 `@` 输入触发，你现在可以在一个会话里 `@` 引用另一个会话。这是个好功能，但它回答的是另一个问题。
+
+`@` 是**加**：把另一个会话历史的一份有界只读快照，挂到你**当前所在**的这个会话上。
+Bridge 是**搬**：把会话压缩成固定的五段 schema，交给目标 preset 下的**新会话**，原会话不动。
+
+这个区别恰好在本插件存在的那个场景上最要命。你要引用的那段历史是在**旧 preset** 下产生的——连同工具调用——而这正是跨 preset 交接最想丢掉的东西（「迁状态不迁痕迹」）；而且它到达的形态是原始转录，不是「目标 / 当前状态 / 关键决策 / 关键文件 / 下一步」。
+
+经验法则：想从旧会话里捞一个事实 → `@`；想换个模式把活继续干下去 → `/bridge`。
+
 ## 测试与验证
 
 - `npm test` 跑 **95 条测试**：压缩取材行为（含**语义**断言——「取材被裁时，最新的那条还在吗」）、会话事件折叠器、摘要五段 schema 契约、**`/bridge` 命令端到端**、进程内 `ctx.apiProxy` 适配器、对着假 dsh host 的完整迁移流水线、以及 CLI 端到端（真进程、真 HTTP 网关、真线协议信封）。全部不需要真的 host，也不烧一个 token。

--- a/README.zh.md
+++ b/README.zh.md
@@ -4,7 +4,7 @@
 [![ci](https://github.com/Totoro-qaq/dsh-plugin-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/Totoro-qaq/dsh-plugin-bridge/actions/workflows/ci.yml)
 [![license](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![node ≥22](https://img.shields.io/badge/node-%E2%89%A522-339933)](package.json)
-[![dsh 0.1.0-rc.6 · rc.7](https://img.shields.io/badge/dsh-0.1.0--rc.6%20%C2%B7%20rc.7-4c8dff)](https://github.com/deepseek-ai/deepseek-harness)
+[![dsh 0.1.0-rc.6 · rc.7 · rc.8](https://img.shields.io/badge/dsh-rc.6%20%C2%B7%20rc.7%20%C2%B7%20rc.8-4c8dff)](https://github.com/deepseek-ai/deepseek-harness)
 [![presets](https://img.shields.io/badge/presets-standard%20%C2%B7%20code%20%C2%B7%20minimal%20%C2%B7%20cordis-4c8dff)](https://github.com/deepseek-ai/deepseek-harness)
 
 [English](README.md) | 中文
@@ -164,9 +164,21 @@ dsh-bridge migrate --to code --summary-file <path>
 ## 测试与验证
 
 - `npm test` 跑 **95 条测试**：压缩取材行为（含**语义**断言——「取材被裁时，最新的那条还在吗」）、会话事件折叠器、摘要五段 schema 契约、**`/bridge` 命令端到端**、进程内 `ctx.apiProxy` 适配器、对着假 dsh host 的完整迁移流水线、以及 CLI 端到端（真进程、真 HTTP 网关、真线协议信封）。全部不需要真的 host，也不烧一个 token。
+- `test/upstream-contract.test.mjs` 把插件赖以立足的那一小片上游面钉住了——十二个 RPC 方法名、命令定义形状、以及对上游后加字段的容忍（rc.8 的 `attachments` 就是这么加进来的）。dsh 是 developer preview，README 自己就写着会有破坏性变更；这道护栏让 CI 先发现，而不是用户先发现。
 - `npm test` 同时对 `src/` **和** `eval/` 做类型检查——评测脚本 import 的就是命令用的那些模块，不可能再和产品路径漂开。
 - CI 额外校验 `lib/` 与 `src/` 同步、数据集可解析、`npm pack` 内容完整，Node 22 与 24 各跑一遍。
 - ⚠️ **尚未在真实 host 上验过。** 每一条 RPC 签名、命令派发的契约、`ctx.apiProxy` 的服务形状都对着上游源码核过，假 host 实现的就是那份契约——但还没有人在跑着的 `dsh web` 里真的敲过一次 `/bridge`。请先做这件事；CLI 那侧的同名假设可以用 `dsh-bridge doctor` 覆盖。
+
+## dsh 兼容性
+
+已对着 **0.1.0-rc.6、rc.7、rc.8** 逐条核对：本插件用到的面（`ctx.commands.register`、`ctx.apiProxy`、十二个 RPC 方法、goal 服务、compaction 检查点标记）在三个版本上完全一致。rc.8 对命令注册表的改动（调用可携带图片附件）是增量的，不影响 `/bridge`——我们没有声明 `input.images`，注册表会替我们挡下带图片的调用。
+
+以后上游真挪了东西，`/bridge --doctor` 会把缺的方法点名说出来，而不是含糊地失败：
+
+```
+网关：进程内 ctx.apiProxy · 10/12 个方法可用
+⚠ 缺少：session.rename, goal.create
+```
 
 ## 配置
 
@@ -188,7 +200,7 @@ dsh-bridge migrate --to code --summary-file <path>
 ## 已知局限与待办
 
 - **`/bridge <preset>` 会阻塞到压缩工人跑完**（通常 20–60 秒，上限由 `previewTimeoutMs` 控制）。命令结果是同步返回的，所以工人特别慢时可能拖过客户端的 RPC 超时——迁移引擎本身不受影响，CLI 那条路也没有这个天花板。
-- **依赖 `commands` 与 `apiProxy`。** 两者在官方 `web` profile 里都在（base 挂命令注册表，web bundle 挂 API 网关）。缺其一时插件会挂起等待而不是半挂——是响的，不是哑的。
+- **依赖 `commands` 与 `apiProxy`。** 两者在官方 `web` profile 里都在（base 挂命令注册表，web bundle 挂 API 网关）。缺其一时插件会挂起等待而不是半挂——是响的，不是哑的。`/bridge --doctor` 会报出这套 host 实际暴露了十二个网关方法里的哪几个。
 - **压缩工人用不上原会话的 KV 缓存。** 上游自己的 compaction 后端会把会话前缀原样重放，正是为了让这次辅助调用成为上次路由请求的真前缀；本插件是另起一个工人会话，前缀毫无关系。实测到的缓存命中是跨 run 的指令重复，不是热前缀复用。要做对得在进程内调 `ctx.llm.stream()`——待办。
 - **取材里 compaction 摘要和它压掉的用户消息仍然重复计费。** `session.history` 读的是日志，检查点和被它替换的消息都还在。
 - **结构化输出会比 markdown 契约更好。** `ctx.subagents` 支持给子会话指定 JSON schema（以及模型、persona、工具限制），那会让「固定五段」从一个需要测量的性质变成类型保证。这一版为了能对着已发布的 rc 核验而没有做。

--- a/docs/guide.zh.md
+++ b/docs/guide.zh.md
@@ -4,7 +4,7 @@
 
 ## 1. 安装
 
-前置：已安装 dsh（`dsh --version` 能输出版本，本插件在 0.1.0-rc.6 / rc.7 上核对过接口），并有一个可跑的 web profile（跑过一次 `dsh web` 即会自动初始化）。
+前置：已安装 dsh（`dsh --version` 能输出版本，本插件在 0.1.0-rc.6 / rc.7 / rc.8 上核对过接口），并有一个可跑的 web profile（跑过一次 `dsh web` 即会自动初始化）。
 
 ```bash
 dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#main
@@ -120,6 +120,9 @@ dsh-bridge migrate --to code --summary-file <path>
 
 **Q：`/bridge` 打了没反应 / 提示未知命令？**
 A：确认重启过 `dsh web`（插件在启动时挂载），并且用的是 `web` profile。命令注册依赖 `commands` 服务、执行依赖 `apiProxy` 服务，两者在官方 web profile 里都在；缺其一插件会挂起等待而不是半挂，日志里能看到。
+
+**Q：升级了 dsh 之后还能用吗？**
+A：先打一次 `/bridge --doctor`，它会告诉你这套 host 暴露了十二个网关方法里的哪几个、当前模式是什么、生效配置是什么。全绿就是好的。缺方法它会点名，把那行连同你的 dsh 版本发到 issues 就行。rc.6 / rc.7 / rc.8 都逐条核对过，本插件用到的面在这三个版本上完全一致。
 
 **Q：迁移后新会话「记得」多少？**
 A：26 组实验的探针可用性（事实可回忆率）：pro 档位 95%。丢的通常是「数字合理化」一类（端口被补全成常见值）——所以预览那一步请重点扫数字。

--- a/lib/api-rpc.d.ts
+++ b/lib/api-rpc.d.ts
@@ -43,6 +43,18 @@ export interface ApiProxyLike {
 }
 /** 本适配器支持的方法名（测试与自检用）。 */
 export declare const SUPPORTED_METHODS: readonly string[];
+/** 一个方法在当前 host 上是否可达。 */
+export interface MethodProbe {
+    method: string;
+    available: boolean;
+}
+/**
+ * 探测这套 host 的网关面是否还是本插件预期的形状。
+ *
+ * 上游是 developer preview，README 明说会有破坏性变更。与其等用户报「插件用不了」，
+ * 不如让 `/bridge --doctor` 直接把缺了哪个方法说出来。只读方法表，不发起任何调用。
+ */
+export declare function probeApiProxy(apiProxy: Partial<ApiProxyLike> | undefined): MethodProbe[];
 /**
  * 建一个直连 `ctx.apiProxy` 的 Rpc。
  * @param apiProxy - host 上的网关服务。

--- a/lib/api-rpc.js
+++ b/lib/api-rpc.js
@@ -29,6 +29,21 @@ const ROUTES = {
 /** 本适配器支持的方法名（测试与自检用）。 */
 export const SUPPORTED_METHODS = Object.keys(ROUTES);
 /**
+ * 探测这套 host 的网关面是否还是本插件预期的形状。
+ *
+ * 上游是 developer preview，README 明说会有破坏性变更。与其等用户报「插件用不了」，
+ * 不如让 `/bridge --doctor` 直接把缺了哪个方法说出来。只读方法表，不发起任何调用。
+ */
+export function probeApiProxy(apiProxy) {
+    return SUPPORTED_METHODS.map((method) => {
+        const route = ROUTES[method];
+        const domain = route?.[0];
+        const key = route?.[1];
+        const fn = domain && key ? apiProxy?.[domain]?.[key] : undefined;
+        return { method, available: typeof fn === 'function' };
+    });
+}
+/**
  * 建一个直连 `ctx.apiProxy` 的 Rpc。
  * @param apiProxy - host 上的网关服务。
  * @param signal - 派发方的取消信号（命令处理器拿到的那个）。

--- a/lib/command.d.ts
+++ b/lib/command.d.ts
@@ -14,6 +14,7 @@
  * model.」——所以在官方 WebUI 的输入框里打 `/bridge code` 就能用。
  */
 import { type InjectMode, type Lang, type ModelTier } from './migrate.ts';
+import type { MethodProbe } from './api-rpc.ts';
 import { type Rpc } from './rpc.ts';
 /** 命令处理器从注册表拿到的东西（结构化声明，不 import 上游类型）。 */
 export interface BridgeInvocation {
@@ -26,6 +27,12 @@ export interface BridgeInvocation {
         };
     };
     rawInput?: string;
+    /**
+     * rc.8 起注册表会传这个字段（随命令提交的图片块）。`/bridge` 没有声明
+     * `input.images`，所以带图片的调用会在进入这里之前就被注册表挡下来；
+     * 声明出来只是为了让类型如实反映上游传了什么。
+     */
+    attachments?: readonly unknown[];
     signal?: AbortSignal;
 }
 export type BridgeResult = {
@@ -50,6 +57,8 @@ export interface BridgeCommandConfig {
 export interface BridgeCommandDeps {
     /** 按本次调用的取消信号建一个 Rpc。 */
     rpcFor: (signal?: AbortSignal) => Rpc;
+    /** 自检：这套 host 的网关面还是不是插件预期的形状。 */
+    probe?: () => MethodProbe[];
     config: BridgeCommandConfig;
     /** 摘要落盘，返回路径；给「改完再执行」这条路用。失败返回 undefined。 */
     writeSummary?: (sessionId: string, summary: string) => string | undefined;
@@ -59,6 +68,7 @@ export interface BridgeCommandDeps {
 interface ParsedInput {
     preset?: string;
     go: boolean;
+    doctor: boolean;
     tier?: ModelTier;
     lang?: Lang;
     inject?: InjectMode;

--- a/lib/command.js
+++ b/lib/command.js
@@ -20,7 +20,7 @@ const PENDING_TTL_MS = 30 * 60_000;
 /** `<preset> [--go] [--tier x] [--lang l] [--inject m] [--goal-rounds n] [--file p]` */
 export function parseBridgeInput(rawInput) {
     const tokens = rawInput.trim().split(/\s+/).filter(Boolean);
-    const out = { go: false, help: false };
+    const out = { go: false, help: false, doctor: false };
     for (let i = 0; i < tokens.length; i += 1) {
         const token = tokens[i];
         if (!token.startsWith('--')) {
@@ -48,6 +48,9 @@ export function parseBridgeInput(rawInput) {
                 break;
             case 'help':
                 out.help = true;
+                break;
+            case 'doctor':
+                out.doctor = true;
                 break;
             case 'tier': {
                 const value = take();
@@ -102,6 +105,7 @@ function usage(presets, current) {
         ...(current ? [`当前：${current}`] : []),
         '',
         '可选：--tier flash|current|pro · --lang zh|en|auto · --goal-rounds N · --file <改过的摘要文件>',
+        '排查：/bridge --doctor',
     ].join('\n');
 }
 /** 建一个 `/bridge` 命令定义。返回值形状对齐上游 `CommandDefinition`。 */
@@ -111,7 +115,7 @@ export function createBridgeCommand(deps) {
     return {
         name: 'bridge',
         description: '把这个会话迁移到另一个工具模式（preset），原会话保持不动',
-        input: { hint: '<preset> [--go]' },
+        input: { hint: '<preset> [--go] | --doctor' },
         handler: async (invocation) => {
             const sessionId = invocation.agent?.session?.id ?? invocation.agent?.session?.header?.id;
             if (!sessionId)
@@ -129,6 +133,25 @@ export function createBridgeCommand(deps) {
             }
             catch (error) {
                 return { kind: 'error', text: describe(error) };
+            }
+            if (parsed.doctor) {
+                const probes = deps.probe?.() ?? [];
+                const missing = probes.filter((probe) => !probe.available).map((probe) => probe.method);
+                const lines = [
+                    `网关：进程内 ctx.apiProxy · ${probes.length - missing.length}/${probes.length} 个方法可用`,
+                    `当前模式：${current ?? '（读不到）'}`,
+                    `可迁入：${presets.filter((p) => p.id !== current).map((p) => p.id).join(' · ') || '（无）'}`,
+                    `配置：档位 ${config.modelTier} · 取材 ${config.sourceCharBudget} 字符 · 摘要 ${config.summaryCharBudget} 字符`
+                        + ` · goal ${config.goalRounds} 轮 · 注入 ${config.inject}`,
+                ];
+                if (missing.length) {
+                    lines.push('');
+                    lines.push(`⚠ 缺少：${missing.join(', ')}`);
+                    lines.push('这套 host 的网关面和插件预期的不一致（上游是 developer preview，接口会变）。');
+                    lines.push('请到 https://github.com/Totoro-qaq/dsh-plugin-bridge/issues 报一下你的 dsh 版本。');
+                    return { kind: 'error', text: lines.join('\n') };
+                }
+                return { kind: 'success', text: lines.join('\n') };
             }
             if (parsed.help || !parsed.preset)
                 return { kind: 'success', text: usage(presets, current) };

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -35,15 +35,15 @@ export interface Config {
 export declare const Config: Schema<Config>;
 /** 把 Config 解析成命令层要的形状（Schema 已经填过默认值，这里只兜底）。 */
 export declare function commandConfigOf(config?: Config): {
-    readonly modelTier: "current" | "flash" | "pro";
+    readonly workerModel?: string | undefined;
+    readonly workerProvider?: string | undefined;
+    readonly modelTier: "flash" | "current" | "pro";
     readonly sourceCharBudget: number;
     readonly summaryCharBudget: number;
     readonly goalRounds: number;
-    readonly inject: "both" | "goal" | "prompt";
-    readonly lang: "auto" | "en" | "zh";
+    readonly inject: "prompt" | "goal" | "both";
+    readonly lang: "zh" | "en" | "auto";
     readonly previewTimeoutMs: number;
-    readonly workerProvider?: string | undefined;
-    readonly workerModel?: string | undefined;
 };
 export declare function apply(ctx: Context, config?: Config): void;
 declare const _default: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import Schema from '@deepseek-ai/schemastery';
-import { createApiProxyRpc } from './api-rpc.js';
+import { createApiProxyRpc, probeApiProxy } from './api-rpc.js';
 import { createBridgeCommand } from './command.js';
 import { SOURCE_CHAR_BUDGET, SUMMARY_CHAR_BUDGET } from './compression.js';
 export const name = 'dsh-plugin-bridge';
@@ -63,8 +63,10 @@ export function commandConfigOf(config = {}) {
     };
 }
 export function apply(ctx, config = {}) {
+    const apiProxyOf = () => ctx.apiProxy;
     const command = createBridgeCommand({
-        rpcFor: (signal) => createApiProxyRpc(ctx.apiProxy, signal),
+        rpcFor: (signal) => createApiProxyRpc(apiProxyOf(), signal),
+        probe: () => probeApiProxy(apiProxyOf()),
         config: commandConfigOf(config),
         writeSummary: writeSummaryFile,
         readSummary: (path) => readFileSync(path, 'utf8'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-plugin-bridge",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "DeepSeek Harness Cordis bundle for cross-preset session migration via fixed-schema handoff summaries",
   "type": "module",
   "main": "lib/index.js",
@@ -38,15 +38,13 @@
     "node": ">=22"
   },
   "peerDependencies": {
-    "@deepseek-ai/cordis": "^4.0.1",
-    "@deepseek-ai/dsh-skill": "^0.1.0-rc.6"
+    "@deepseek-ai/cordis": "^4.0.1"
   },
   "dependencies": {
     "@deepseek-ai/schemastery": "^3.18.1"
   },
   "devDependencies": {
     "@deepseek-ai/cordis": "4.0.1",
-    "@deepseek-ai/dsh-skill": "0.1.0-rc.6",
     "@types/node": "^26.2.0",
     "typescript": "^7.0.2"
   },

--- a/src/api-rpc.ts
+++ b/src/api-rpc.ts
@@ -56,6 +56,28 @@ const ROUTES: Record<string, [keyof ApiProxyLike, string]> = {
 /** 本适配器支持的方法名（测试与自检用）。 */
 export const SUPPORTED_METHODS: readonly string[] = Object.keys(ROUTES);
 
+/** 一个方法在当前 host 上是否可达。 */
+export interface MethodProbe {
+  method: string;
+  available: boolean;
+}
+
+/**
+ * 探测这套 host 的网关面是否还是本插件预期的形状。
+ *
+ * 上游是 developer preview，README 明说会有破坏性变更。与其等用户报「插件用不了」，
+ * 不如让 `/bridge --doctor` 直接把缺了哪个方法说出来。只读方法表，不发起任何调用。
+ */
+export function probeApiProxy(apiProxy: Partial<ApiProxyLike> | undefined): MethodProbe[] {
+  return SUPPORTED_METHODS.map((method) => {
+    const route = ROUTES[method];
+    const domain = route?.[0];
+    const key = route?.[1];
+    const fn = domain && key ? (apiProxy as ApiProxyLike | undefined)?.[domain]?.[key] : undefined;
+    return { method, available: typeof fn === 'function' };
+  });
+}
+
 /**
  * 建一个直连 `ctx.apiProxy` 的 Rpc。
  * @param apiProxy - host 上的网关服务。

--- a/src/command.ts
+++ b/src/command.ts
@@ -25,12 +25,19 @@ import {
   type ModelTier,
   type PresetRow,
 } from './migrate.ts';
+import type { MethodProbe } from './api-rpc.ts';
 import { RpcError, type Rpc } from './rpc.ts';
 
 /** 命令处理器从注册表拿到的东西（结构化声明，不 import 上游类型）。 */
 export interface BridgeInvocation {
   agent?: { session?: { id?: string; header?: { id?: string } } };
   rawInput?: string;
+  /**
+   * rc.8 起注册表会传这个字段（随命令提交的图片块）。`/bridge` 没有声明
+   * `input.images`，所以带图片的调用会在进入这里之前就被注册表挡下来；
+   * 声明出来只是为了让类型如实反映上游传了什么。
+   */
+  attachments?: readonly unknown[];
   signal?: AbortSignal;
 }
 
@@ -54,6 +61,8 @@ export interface BridgeCommandConfig {
 export interface BridgeCommandDeps {
   /** 按本次调用的取消信号建一个 Rpc。 */
   rpcFor: (signal?: AbortSignal) => Rpc;
+  /** 自检：这套 host 的网关面还是不是插件预期的形状。 */
+  probe?: () => MethodProbe[];
   config: BridgeCommandConfig;
   /** 摘要落盘，返回路径；给「改完再执行」这条路用。失败返回 undefined。 */
   writeSummary?: (sessionId: string, summary: string) => string | undefined;
@@ -75,6 +84,7 @@ const PENDING_TTL_MS = 30 * 60_000;
 interface ParsedInput {
   preset?: string;
   go: boolean;
+  doctor: boolean;
   tier?: ModelTier;
   lang?: Lang;
   inject?: InjectMode;
@@ -87,7 +97,7 @@ interface ParsedInput {
 /** `<preset> [--go] [--tier x] [--lang l] [--inject m] [--goal-rounds n] [--file p]` */
 export function parseBridgeInput(rawInput: string): ParsedInput {
   const tokens = rawInput.trim().split(/\s+/).filter(Boolean);
-  const out: ParsedInput = { go: false, help: false };
+  const out: ParsedInput = { go: false, help: false, doctor: false };
   for (let i = 0; i < tokens.length; i += 1) {
     const token = tokens[i] as string;
     if (!token.startsWith('--')) {
@@ -108,6 +118,7 @@ export function parseBridgeInput(rawInput: string): ParsedInput {
     switch (key) {
       case 'go': out.go = true; break;
       case 'help': out.help = true; break;
+      case 'doctor': out.doctor = true; break;
       case 'tier': {
         const value = take();
         if (value !== 'flash' && value !== 'current' && value !== 'pro') {
@@ -158,6 +169,7 @@ function usage(presets: PresetRow[], current: string | undefined): string {
     ...(current ? [`当前：${current}`] : []),
     '',
     '可选：--tier flash|current|pro · --lang zh|en|auto · --goal-rounds N · --file <改过的摘要文件>',
+    '排查：/bridge --doctor',
   ].join('\n');
 }
 
@@ -174,7 +186,7 @@ export function createBridgeCommand(deps: BridgeCommandDeps): {
   return {
     name: 'bridge',
     description: '把这个会话迁移到另一个工具模式（preset），原会话保持不动',
-    input: { hint: '<preset> [--go]' },
+    input: { hint: '<preset> [--go] | --doctor' },
     handler: async (invocation: BridgeInvocation): Promise<BridgeResult> => {
       const sessionId = invocation.agent?.session?.id ?? invocation.agent?.session?.header?.id;
       if (!sessionId) return { kind: 'error', text: '取不到当前会话身份，无法迁移。' };
@@ -192,6 +204,26 @@ export function createBridgeCommand(deps: BridgeCommandDeps): {
         current = (await findSession(rpc, sessionId))?.agentPreset;
       } catch (error) {
         return { kind: 'error', text: describe(error) };
+      }
+
+      if (parsed.doctor) {
+        const probes = deps.probe?.() ?? [];
+        const missing = probes.filter((probe) => !probe.available).map((probe) => probe.method);
+        const lines = [
+          `网关：进程内 ctx.apiProxy · ${probes.length - missing.length}/${probes.length} 个方法可用`,
+          `当前模式：${current ?? '（读不到）'}`,
+          `可迁入：${presets.filter((p) => p.id !== current).map((p) => p.id).join(' · ') || '（无）'}`,
+          `配置：档位 ${config.modelTier} · 取材 ${config.sourceCharBudget} 字符 · 摘要 ${config.summaryCharBudget} 字符`
+          + ` · goal ${config.goalRounds} 轮 · 注入 ${config.inject}`,
+        ];
+        if (missing.length) {
+          lines.push('');
+          lines.push(`⚠ 缺少：${missing.join(', ')}`);
+          lines.push('这套 host 的网关面和插件预期的不一致（上游是 developer preview，接口会变）。');
+          lines.push('请到 https://github.com/Totoro-qaq/dsh-plugin-bridge/issues 报一下你的 dsh 版本。');
+          return { kind: 'error', text: lines.join('\n') };
+        }
+        return { kind: 'success', text: lines.join('\n') };
       }
 
       if (parsed.help || !parsed.preset) return { kind: 'success', text: usage(presets, current) };

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { join } from 'node:path'
 import type { Context } from '@deepseek-ai/cordis'
 import Schema from '@deepseek-ai/schemastery'
 
-import { createApiProxyRpc, type ApiProxyLike } from './api-rpc.ts'
+import { createApiProxyRpc, probeApiProxy, type ApiProxyLike } from './api-rpc.ts'
 import { createBridgeCommand } from './command.ts'
 import { SOURCE_CHAR_BUDGET, SUMMARY_CHAR_BUDGET } from './compression.ts'
 
@@ -98,8 +98,10 @@ export function commandConfigOf(config: Config = {}) {
 }
 
 export function apply(ctx: Context, config: Config = {}): void {
+  const apiProxyOf = (): ApiProxyLike => (ctx as unknown as { apiProxy: ApiProxyLike }).apiProxy
   const command = createBridgeCommand({
-    rpcFor: (signal) => createApiProxyRpc((ctx as unknown as { apiProxy: ApiProxyLike }).apiProxy, signal),
+    rpcFor: (signal) => createApiProxyRpc(apiProxyOf(), signal),
+    probe: () => probeApiProxy(apiProxyOf()),
     config: commandConfigOf(config),
     writeSummary: writeSummaryFile,
     readSummary: (path) => readFileSync(path, 'utf8'),

--- a/test/command.test.mjs
+++ b/test/command.test.mjs
@@ -9,7 +9,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { createFakeHost } from './fake-host.mjs';
-import { createApiProxyRpc, SUPPORTED_METHODS } from '../src/api-rpc.ts';
+import { createApiProxyRpc, probeApiProxy, SUPPORTED_METHODS } from '../src/api-rpc.ts';
 import { createBridgeCommand, parseBridgeInput } from '../src/command.ts';
 
 const CONFIG = {
@@ -27,6 +27,7 @@ function setup(hostOptions = {}, overrides = {}) {
   const files = new Map();
   const command = createBridgeCommand({
     rpcFor: (signal) => createApiProxyRpc(host.apiProxy, signal),
+    probe: () => probeApiProxy(host.apiProxy),
     config: { ...CONFIG, ...overrides },
     writeSummary: (sessionId, summary) => {
       const path = `/tmp/fake-${sessionId}.md`;
@@ -38,8 +39,9 @@ function setup(hostOptions = {}, overrides = {}) {
       return files.get(path);
     },
   });
+  // attachments 是 rc.8 起注册表必传的字段，这里跟着传，免得测试比真实调用更宽松。
   const invoke = (rawInput, sessionId = host.sourceSessionId) =>
-    command.handler({ agent: { session: { id: sessionId } }, rawInput, signal: undefined });
+    command.handler({ agent: { session: { id: sessionId } }, rawInput, attachments: [], signal: undefined });
   return { host, command, invoke, files };
 }
 
@@ -49,6 +51,7 @@ test('命令定义形状符合上游 CommandDefinition', () => {
   assert.ok(command.description.length > 10);
   assert.equal(typeof command.handler, 'function');
   assert.ok(command.input.hint.includes('preset'));
+  assert.ok(command.input.hint.includes('--doctor'), '自检入口要出现在提示里');
 });
 
 test('/bridge 不带参数：列出可迁入的模式与当前模式', async () => {
@@ -171,7 +174,8 @@ test('--tier 覆盖部署默认档位', async () => {
 });
 
 test('参数解析', () => {
-  assert.deepEqual(parseBridgeInput('code'), { preset: 'code', go: false, help: false });
+  assert.deepEqual(parseBridgeInput('code'), { preset: 'code', go: false, help: false, doctor: false });
+  assert.equal(parseBridgeInput('--doctor').doctor, true);
   assert.equal(parseBridgeInput('code --go').go, true);
   assert.equal(parseBridgeInput('code --tier=flash').tier, 'flash');
   assert.equal(parseBridgeInput('  code   --goal-rounds 3 ').goalRounds, 3);

--- a/test/upstream-contract.test.mjs
+++ b/test/upstream-contract.test.mjs
@@ -1,0 +1,143 @@
+/**
+ * 上游契约护栏。
+ *
+ * dsh 还是 developer preview，README 明说会有破坏性变更。这个插件依赖的上游面
+ * 其实很窄——一个命令注册契约、一个 `ctx.apiProxy` 服务、12 个 RPC 方法名。
+ * 把它们钉在这里，下一次 rc 变形时是 CI 先说话，而不是用户先说话。
+ *
+ * 核对基线：dsh 0.1.0-rc.6 / rc.7 / rc.8（三个版本上这些面完全一致）。
+ * 上游出处见每条断言的注释。
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createFakeHost } from './fake-host.mjs';
+import { createApiProxyRpc, probeApiProxy, SUPPORTED_METHODS } from '../src/api-rpc.ts';
+import { createBridgeCommand } from '../src/command.ts';
+
+/**
+ * 我们用到的 RPC 方法名，必须是上游 `RpcMethodMap` 的键
+ * （packages/host/apiproxy/src/api/rpc-map.ts）。
+ */
+const REQUIRED_METHODS = [
+  'session.list',
+  'session.create',
+  'session.history',
+  'session.models',
+  'session.selectModel',
+  'session.prompt',
+  'session.cancel',
+  'session.rename',
+  'workspace.list',
+  'workspace.archiveSession',
+  'agentPreset.list',
+  'goal.create',
+];
+
+const CONFIG = {
+  modelTier: 'pro',
+  sourceCharBudget: 60_000,
+  summaryCharBudget: 2_400,
+  goalRounds: 1,
+  inject: 'both',
+  lang: 'auto',
+  previewTimeoutMs: 5_000,
+};
+
+function commandOn(host, overrides = {}) {
+  return createBridgeCommand({
+    rpcFor: (signal) => createApiProxyRpc(host.apiProxy, signal),
+    probe: () => probeApiProxy(host.apiProxy),
+    config: CONFIG,
+    ...overrides,
+  });
+}
+
+test('依赖的 RPC 方法集是冻结的：多一个少一个都要显式改这里', () => {
+  assert.deepEqual([...SUPPORTED_METHODS].sort(), [...REQUIRED_METHODS].sort());
+});
+
+test('命令定义形状符合上游 CommandDefinition（name/description/input.hint/handler）', () => {
+  // packages/interaction/commands/src/index.ts · normalizeDefinition()
+  const command = commandOn(createFakeHost());
+  assert.equal(typeof command.name, 'string');
+  assert.match(command.name, /^[a-z][a-z0-9_-]*$/u, '上游 COMMAND_NAME 的语法');
+  assert.ok(command.description.trim().length > 0, '上游要求 description 非空');
+  assert.ok(command.input.hint.trim().length > 0, '上游要求 hint 非空');
+  assert.equal(typeof command.handler, 'function');
+  // 我们没有声明 input.images：rc.8 起注册表会替我们挡下带图片的调用。
+  assert.equal(command.input.images, undefined);
+});
+
+test('处理器容忍上游后加的字段（rc.8 的 attachments，以及任何未知字段）', async () => {
+  const host = createFakeHost();
+  const command = commandOn(host);
+  const result = await command.handler({
+    commandId: 'cmd-1',
+    agent: { session: { id: host.sourceSessionId, header: { id: host.sourceSessionId } } },
+    rawInput: '',
+    attachments: [],            // rc.8 新增
+    somethingAddedInRc9: true,  // 未来
+    signal: undefined,
+  });
+  assert.equal(result.kind, 'success');
+  assert.match(result.text, /可迁入/);
+});
+
+test('会话身份两种取法都认（agent.session.id 与 agent.session.header.id）', async () => {
+  const host = createFakeHost();
+  const command = commandOn(host);
+  const viaHeader = await command.handler({
+    agent: { session: { header: { id: host.sourceSessionId } } },
+    rawInput: '--doctor',
+  });
+  assert.equal(viaHeader.kind, 'success', viaHeader.text);
+});
+
+test('--doctor：网关面完好时报全绿', async () => {
+  const host = createFakeHost();
+  const result = await commandOn(host).handler({
+    agent: { session: { id: host.sourceSessionId } },
+    rawInput: '--doctor',
+  });
+  assert.equal(result.kind, 'success', result.text);
+  assert.match(result.text, new RegExp(`${REQUIRED_METHODS.length}/${REQUIRED_METHODS.length} 个方法可用`));
+  assert.match(result.text, /当前模式：minimal/);
+  assert.match(result.text, /档位 pro/);
+});
+
+test('--doctor：上游少了方法时点名说出来，而不是等用户报「用不了」', async () => {
+  const host = createFakeHost();
+  delete host.apiProxy.sessions.rename;
+  delete host.apiProxy.goals.create;
+  const result = await commandOn(host).handler({
+    agent: { session: { id: host.sourceSessionId } },
+    rawInput: '--doctor',
+  });
+  assert.equal(result.kind, 'error');
+  assert.match(result.text, /10\/12 个方法可用/);
+  assert.match(result.text, /session\.rename/);
+  assert.match(result.text, /goal\.create/);
+  assert.match(result.text, /issues/, '要告诉用户去哪儿报');
+});
+
+test('probeApiProxy：整个服务缺失时不炸，全部标记为不可用', () => {
+  assert.deepEqual(probeApiProxy(undefined).filter((p) => p.available), []);
+  assert.equal(probeApiProxy(undefined).length, REQUIRED_METHODS.length);
+});
+
+test('适配器对上游移除的方法是响的，不是哑的', async () => {
+  const host = createFakeHost();
+  delete host.apiProxy.goals.create;
+  const rpc = createApiProxyRpc(host.apiProxy);
+  await assert.rejects(() => rpc('goal.create', {}), /apiProxy 上没有 goals\.create/);
+});
+
+test('信封解析对齐上游 unary 方法的返回形状', async () => {
+  // { rpcId, result: { ok, value } | { ok: false, error: { code, message } } }
+  const host = createFakeHost();
+  const rpc = createApiProxyRpc(host.apiProxy);
+  const value = await rpc('workspace.list', {});
+  assert.ok(Array.isArray(value.items), 'ok 时应当拿到 result.value 本身');
+  await assert.rejects(() => rpc('session.history', { sessionId: 'nope' }), /session-not-found|没有这个会话/);
+});


### PR DESCRIPTION
- **chore: 对齐 dsh 0.1.0-rc.8，并给上游接口变动加一道护栏**
- **docs: 说清楚和 rc.8 新增的 `@` 引用会话是什么关系**
