### PR TITLE
fix: close the goal.pause fail-closed race

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Move a produced DeepSeek Harness session to another tool preset through a previe
 ## Quick start
 
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.6
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.7
 # restart dsh web once
 ```
 
@@ -50,7 +50,7 @@ Bridge optimizes for **high-fidelity, bounded-cost migration**:
 - **Default — accuracy first:** the target restates the handoff in one short turn and waits. You verify it before any work starts.
 - **`--continue` — lower latency/cost:** the target restates and begins the next step in the **same model request**.
 - In both confirmation modes, any stored goal is paused before kickoff. The goal driver cannot silently queue another model round.
-- If pausing fails, Bridge fails closed: it cancels automatic startup and sends no kickoff.
+- If pausing fails, Bridge fails closed: it clears the stored goal, cancels the target session, and sends no kickoff.
 - Installing the plugin adds **zero prompt tokens** to normal sessions. `/bridge` is a host slash command, not a model tool or skill.
 - Existing image analysis is copied verbatim outside the compressed summary. Only unresolved images may use vision tokens, and only when the target accepts images.
 
@@ -150,6 +150,8 @@ The normal five-part summary remains bounded by `summaryCharBudget` (2,400 chara
 
 rc.6/rc.7 remain compatible through the text path. Raw attachment recovery is an optional rc.8+ gateway capability and does not become a required `/bridge --doctor` method. The full raw-image path is live-tested on 0.1.1-rc.2 with `deepseek-v4-flash-vision-exp`.
 
+On 0.1.1-rc.2, `session.selectModel` permits selecting a text-only model even when the session history contains images; `session.prompt` still enforces image capability and triggers Bridge's explicit text fallback. Bridge copies the source model before kickoff so a preview worker or host default cannot silently replace the source VLM.
+
 </details>
 
 <details>
@@ -180,6 +182,7 @@ Verified against DeepSeek Harness **0.1.0-rc.6, rc.7, rc.8, and 0.1.1-rc.2**, No
 
 - The official WebUI currently needs one restart after install and cannot let a plugin navigate to the session it creates. Bridge prints the exact title and session ID.
 - DeepSeek text routes still cannot inspect images. Use an image-capable route such as `deepseek-v4-flash-vision-exp` for unresolved images; Bridge preserves that source selection on the target and fails visibly when no reusable attachment is available. It does not run a hidden local vision model.
+- On 0.1.1-rc.2, model selection itself no longer rejects this mismatch; prompt admission remains the enforcement point. Source-model copying is therefore a compatibility safeguard, not just a convenience.
 - Preview normally takes 20–60 seconds and is bounded by `previewTimeoutMs`.
 - Release acceptance now covers real compaction reuse, but only one run per cell; it should not be read as a population guarantee.
 - The older tier-comparison benchmark predates prompt+goal dual injection and remains labeled as historical evidence.

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,7 +20,7 @@
 ## 快速开始
 
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.6
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.7
 # 重启一次 dsh web
 ```
 
@@ -50,7 +50,7 @@ Bridge 的目标是：**高准确率、成本有界的迁移**。
 - **默认模式——准确率优先：**目标会话用一个短轮次复述交接，然后等待；你确认无误后才开工。
 - **`--continue`——更低延迟/成本：**目标会话在**同一次模型请求**里完成复述并开始下一步。
 - 两种确认模式都会在 kickoff 前暂停已存储的 goal（如有），goal driver 不会静默追加模型轮次。
-- pause 失败时 fail closed：取消自动启动，不发送 kickoff。
+- pause 失败时 fail closed：清除已存储的 goal、取消目标会话，不发送 kickoff。
 - 只安装、不迁移时，正常会话增加 **0 prompt token**。`/bridge` 是 host slash command，不是模型工具或 skill。
 - 已有识图结果会在压缩摘要之外逐字搬运；只有尚未解析且目标能接图时才可能产生视觉 token。
 
@@ -150,6 +150,8 @@ Bridge 使用自动、准确率优先的图片策略：
 
 rc.6/rc.7 继续走文本兼容路径。原图读取只是 rc.8+ 的可选网关能力，不会被加入 `/bridge --doctor` 的必需方法集合；0.1.1-rc.2 + `deepseek-v4-flash-vision-exp` 的完整原图迁移已实测通过。
 
+在 0.1.1-rc.2 上，即使会话历史含图，`session.selectModel` 也允许选中纯文本模型；`session.prompt` 仍会执行图片能力准入，并触发 Bridge 的显式文本降级。Bridge 会在 kickoff 前复制源模型，避免预览 worker 或 host 默认值把源 VLM 静默替换掉。
+
 </details>
 
 <details>
@@ -180,6 +182,7 @@ Bridge 尊重这个边界：建立干净的目标会话，只携带一份有界�
 
 - 官方 WebUI 安装后目前需要重启一次，也不允许插件自动跳转到新建会话；Bridge 会打印准确标题与 session ID。
 - DeepSeek 文本路由仍不能读图。未解析图片应使用 `deepseek-v4-flash-vision-exp` 等视觉路由；Bridge 会把源模型选择保留到目标，并在附件不可复用时明确降级，不会暗中运行本地小视觉模型。
+- 在 0.1.1-rc.2 上，模型选择阶段不再拒绝这种不匹配，真正的能力闸留在 prompt 准入；因此复制源模型是兼容性护栏，不只是便利功能。
 - 预览通常需要 20–60 秒，受 `previewTimeoutMs` 上限保护。
 - release acceptance 已覆盖真实 compaction 复用，但每个 cell 仅 1 次，不应理解为总体保证值。
 - 更早的档位对比数据早于 prompt+goal 双注入，继续作为带边界的历史证据。

--- a/docs/guide.zh.md
+++ b/docs/guide.zh.md
@@ -7,7 +7,7 @@
 前置：已安装 dsh（`dsh --version` 能输出版本，本插件已核对 0.1.0-rc.6 / rc.7 / rc.8，并在 0.1.1-rc.2 完成真实视觉迁移），并有一个可跑的 web profile（跑过一次 `dsh web` 即会自动初始化）。
 
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.6
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.7
 ```
 
 发生了什么（不用手动干预）：

--- a/lib/api-rpc.d.ts
+++ b/lib/api-rpc.d.ts
@@ -41,7 +41,7 @@ export interface ApiProxyLike {
     goals: Record<string, UnaryMethod>;
     agentPresets: Record<string, UnaryMethod>;
 }
-/** 主迁移链路必需的方法名（测试与 doctor 用）；不含 rc.8 可选图片读取。 */
+/** 主迁移链路必需的方法名（测试与 doctor 用）；不含可选图片读取与 fail-closed 增强。 */
 export declare const SUPPORTED_METHODS: readonly string[];
 /** 一个方法在当前 host 上是否可达。 */
 export interface MethodProbe {

--- a/lib/api-rpc.js
+++ b/lib/api-rpc.js
@@ -28,9 +28,12 @@ const ROUTES = {
     'agentPreset.list': ['agentPresets', 'list'],
     'goal.create': ['goals', 'create'],
     'goal.pause': ['goals', 'pause'],
+    // pause 失败时的可选 fail-closed 兜底；rc.7+ 有此路由，但不抬高 doctor 基线。
+    'goal.clear': ['goals', 'clear'],
 };
-/** 主迁移链路必需的方法名（测试与 doctor 用）；不含 rc.8 可选图片读取。 */
-export const SUPPORTED_METHODS = Object.keys(ROUTES).filter((method) => method !== 'session.attachment');
+const OPTIONAL_METHODS = new Set(['session.attachment', 'goal.clear']);
+/** 主迁移链路必需的方法名（测试与 doctor 用）；不含可选图片读取与 fail-closed 增强。 */
+export const SUPPORTED_METHODS = Object.keys(ROUTES).filter((method) => !OPTIONAL_METHODS.has(method));
 /**
  * 探测这套 host 的网关面是否还是本插件预期的形状。
  *

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -347,10 +347,21 @@ export async function executeMigration(rpc, options) {
                 goalPaused = true;
             }
             catch (error) {
-                // 安全优先：pause 失败时不再发 kickoff，并尽力取消/解除自动续跑授权。
+                // 安全优先：pause 失败时不再发 kickoff。先清除 goal，挡住尚未入队的
+                // requestDrive；再 cancel，截住已排队或已开始的 attempt。
                 safeToKickoff = false;
+                let goalCleared = false;
+                try {
+                    await rpc('goal.clear', { sessionId: created.sessionId, ref: createdGoal.ref });
+                    goalCleared = true;
+                }
+                catch (clearError) {
+                    warnings.push(`清除未暂停的交接目标失败，已继续取消目标会话；请保持目标会话关闭并手动检查：${clearError instanceof Error ? clearError.message : String(clearError)}`);
+                }
                 await rpc('session.cancel', { sessionId: created.sessionId }).catch(() => undefined);
-                warnings.push(`暂停交接目标失败，已取消自动启动；请打开目标会话检查后手动继续：${error instanceof Error ? error.message : String(error)}`);
+                warnings.push(goalCleared
+                    ? `暂停交接目标失败，已清除目标并取消自动启动；请打开目标会话检查后手动继续：${error instanceof Error ? error.message : String(error)}`
+                    : `暂停交接目标失败，已取消自动启动但无法确认目标已清除；请打开目标会话检查后手动继续：${error instanceof Error ? error.message : String(error)}`);
             }
         }
         catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-plugin-bridge",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-plugin-bridge",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-plugin-bridge",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "DeepSeek Harness Cordis bundle for cross-preset session migration via fixed-schema handoff summaries",
   "type": "module",
   "main": "lib/index.js",

--- a/src/api-rpc.ts
+++ b/src/api-rpc.ts
@@ -54,10 +54,14 @@ const ROUTES: Record<string, [keyof ApiProxyLike, string]> = {
   'agentPreset.list': ['agentPresets', 'list'],
   'goal.create': ['goals', 'create'],
   'goal.pause': ['goals', 'pause'],
+  // pause 失败时的可选 fail-closed 兜底；rc.7+ 有此路由，但不抬高 doctor 基线。
+  'goal.clear': ['goals', 'clear'],
 };
 
-/** 主迁移链路必需的方法名（测试与 doctor 用）；不含 rc.8 可选图片读取。 */
-export const SUPPORTED_METHODS: readonly string[] = Object.keys(ROUTES).filter((method) => method !== 'session.attachment');
+const OPTIONAL_METHODS = new Set(['session.attachment', 'goal.clear']);
+
+/** 主迁移链路必需的方法名（测试与 doctor 用）；不含可选图片读取与 fail-closed 增强。 */
+export const SUPPORTED_METHODS: readonly string[] = Object.keys(ROUTES).filter((method) => !OPTIONAL_METHODS.has(method));
 
 /** 一个方法在当前 host 上是否可达。 */
 export interface MethodProbe {

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -503,10 +503,20 @@ export async function executeMigration(rpc: Rpc, options: MigrateOptions): Promi
         await rpc('goal.pause', { sessionId: created.sessionId, ref: createdGoal.ref });
         goalPaused = true;
       } catch (error) {
-        // 安全优先：pause 失败时不再发 kickoff，并尽力取消/解除自动续跑授权。
+        // 安全优先：pause 失败时不再发 kickoff。先清除 goal，挡住尚未入队的
+        // requestDrive；再 cancel，截住已排队或已开始的 attempt。
         safeToKickoff = false;
+        let goalCleared = false;
+        try {
+          await rpc('goal.clear', { sessionId: created.sessionId, ref: createdGoal.ref });
+          goalCleared = true;
+        } catch (clearError) {
+          warnings.push(`清除未暂停的交接目标失败，已继续取消目标会话；请保持目标会话关闭并手动检查：${clearError instanceof Error ? clearError.message : String(clearError)}`);
+        }
         await rpc('session.cancel', { sessionId: created.sessionId }).catch(() => undefined);
-        warnings.push(`暂停交接目标失败，已取消自动启动；请打开目标会话检查后手动继续：${error instanceof Error ? error.message : String(error)}`);
+        warnings.push(goalCleared
+          ? `暂停交接目标失败，已清除目标并取消自动启动；请打开目标会话检查后手动继续：${error instanceof Error ? error.message : String(error)}`
+          : `暂停交接目标失败，已取消自动启动但无法确认目标已清除；请打开目标会话检查后手动继续：${error instanceof Error ? error.message : String(error)}`);
       }
     } catch (error) {
       // 没挂 goal 服务的部署也应该能迁移：摘要还会走首轮提示。

--- a/test/fake-host.mjs
+++ b/test/fake-host.mjs
@@ -17,6 +17,7 @@ export function createFakeHost(options = {}) {
     startAfterPolls = 0,
     failGoal = false,
     failPause = false,
+    failClear = false,
     sourceImage = undefined,
     targetSupportsImages = false,
     presets = [
@@ -45,6 +46,7 @@ export function createFakeHost(options = {}) {
   const archived = [];
   const goals = [];
   const pausedGoals = [];
+  const clearedGoals = [];
   const renames = [];
   const selected = [];
   const attachments = new Map();
@@ -212,6 +214,11 @@ export function createFakeHost(options = {}) {
         pausedGoals.push({ ...payload });
         return { ref: { id: payload.ref.id, revision: payload.ref.revision + 1 } };
       }
+      case 'goal.clear': {
+        if (failClear) fail('internal', '清除目标失败');
+        clearedGoals.push({ ...payload });
+        return { cleared: true };
+      }
       case 'workspace.list':
         return { items: [{ workspaceId: 'ws-1', path: '/work/shop', sessionIds: [source.sessionId] }], archivedSessionIds: archived };
       case 'workspace.archiveSession':
@@ -249,7 +256,7 @@ export function createFakeHost(options = {}) {
       list: unary('workspace.list'),
       archiveSession: unary('workspace.archiveSession'),
     },
-    goals: { create: unary('goal.create'), pause: unary('goal.pause') },
+    goals: { create: unary('goal.create'), pause: unary('goal.pause'), clear: unary('goal.clear') },
     agentPresets: { list: unary('agentPreset.list') },
   };
 
@@ -257,7 +264,7 @@ export function createFakeHost(options = {}) {
     handle,
     apiProxy,
     sourceSessionId: source.sessionId,
-    state: { sessions, calls, archived, goals, pausedGoals, renames, selected, attachments },
+    state: { sessions, calls, archived, goals, pausedGoals, clearedGoals, renames, selected, attachments },
     /** 把假 host 包成 migrate.ts 需要的 Rpc。 */
     rpc: (method, payload) => handle(method, payload),
   };

--- a/test/migrate.test.mjs
+++ b/test/migrate.test.mjs
@@ -194,7 +194,7 @@ test('migrate：autoContinue 在同一轮继续，但 goal 仍暂停以免追加
   assert.ok(kickoff.payload.content[0].text.includes('继续执行下一步'));
 });
 
-test('migrate：pause 失败时取消自动启动且不发送 kickoff', async () => {
+test('migrate：pause 失败时先清除 goal、再取消自动启动且不发送 kickoff', async () => {
   const host = createFakeHost({ failPause: true });
   const result = await executeMigration(host.rpc, {
     sessionId: host.sourceSessionId,
@@ -204,7 +204,32 @@ test('migrate：pause 失败时取消自动启动且不发送 kickoff', async ()
   });
   assert.equal(result.goalPaused, false);
   assert.equal(result.kickoffSent, false);
-  assert.match(result.warnings.join('\n'), /暂停交接目标失败/);
+  assert.match(result.warnings.join('\n'), /已清除目标并取消自动启动/);
+  assert.equal(host.state.clearedGoals.length, 1);
+  const clearIndex = host.state.calls.findIndex(
+    (c) => c.method === 'goal.clear' && c.payload.sessionId === result.sessionId,
+  );
+  const cancelIndex = host.state.calls.findIndex(
+    (c) => c.method === 'session.cancel' && c.payload.sessionId === result.sessionId,
+  );
+  assert.ok(clearIndex >= 0);
+  assert.ok(cancelIndex > clearIndex, '必须先清掉尚未入队的 goal，再取消已排队或运行中的 attempt');
+  assert.ok(!host.state.calls.some((c) => c.method === 'session.prompt' && c.payload.sessionId === result.sessionId));
+});
+
+test('migrate：旧 host 没有可选 goal.clear 时仍 fail closed，并明确要求人工检查', async () => {
+  const host = createFakeHost({ failPause: true });
+  delete host.apiProxy.goals.clear;
+  const result = await executeMigration(createApiProxyRpc(host.apiProxy), {
+    sessionId: host.sourceSessionId,
+    to: 'code',
+    summary: '## 目标\n端口 7101',
+    lang: 'zh',
+  });
+  assert.equal(result.goalPaused, false);
+  assert.equal(result.kickoffSent, false);
+  assert.match(result.warnings.join('\n'), /无法确认目标已清除/);
+  assert.match(result.warnings.join('\n'), /apiProxy 上没有 goals\.clear/);
   assert.ok(host.state.calls.some((c) => c.method === 'session.cancel' && c.payload.sessionId === result.sessionId));
   assert.ok(!host.state.calls.some((c) => c.method === 'session.prompt' && c.payload.sessionId === result.sessionId));
 });

--- a/test/upstream-contract.test.mjs
+++ b/test/upstream-contract.test.mjs
@@ -5,7 +5,7 @@
  * 其实很窄——一个命令注册契约、一个 `ctx.apiProxy` 服务、13 个 RPC 方法名。
  * 把它们钉在这里，下一次 rc 变形时是 CI 先说话，而不是用户先说话。
  *
- * 核对基线：dsh 0.1.0-rc.6 / rc.7 / rc.8（三个版本上这些面完全一致）。
+ * 核对基线：dsh 0.1.0-rc.6 / rc.7 / rc.8 与 0.1.1-rc.1 / rc.2。
  * 上游出处见每条断言的注释。
  */
 import test from 'node:test';
@@ -62,6 +62,14 @@ test('rc.8 图片读取是可选 RPC，不降低 rc.6/rc.7 主链路兼容性', 
   const host = createFakeHost();
   delete host.apiProxy.sessions.attachment;
   assert.equal(probeApiProxy(host.apiProxy).some((row) => row.method === 'session.attachment'), false);
+});
+
+test('goal.clear 是 pause 失败时的可选 fail-closed RPC，不改变 doctor 13/13', () => {
+  const host = createFakeHost();
+  delete host.apiProxy.goals.clear;
+  assert.equal(SUPPORTED_METHODS.includes('goal.clear'), false);
+  assert.equal(probeApiProxy(host.apiProxy).length, REQUIRED_METHODS.length);
+  assert.equal(probeApiProxy(host.apiProxy).every((row) => row.available), true);
 });
 
 test('命令定义形状符合上游 CommandDefinition（name/description/input.hint/handler）', () => {


### PR DESCRIPTION
## Summary

- clear the newly created goal before cancelling the target when `goal.pause` fails
- keep `goal.clear` optional so `/bridge --doctor` remains 13/13 on older compatible hosts
- document the 0.1.1-rc.2 image-model admission change and source-VLM safeguard
- bump the installable patch release to v0.2.7

## Verification

- `npm test` — 123/123 passed
- `npm run pack:check` — v0.2.7 package assembled successfully
- checked the installed 0.1.1-rc.2 API proxy for `goal.clear` and prompt-time `MODEL_DOES_NOT_SUPPORT_IMAGES`