### PR TITLE
feat: localize /bridge command metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Move a produced DeepSeek Harness session to another tool preset through a previe
 ## Quick start
 
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.7
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.8
 # restart dsh web once
 ```
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,7 +20,7 @@
 ## 快速开始
 
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.7
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.8
 # 重启一次 dsh web
 ```
 

--- a/docs/guide.zh.md
+++ b/docs/guide.zh.md
@@ -7,7 +7,7 @@
 前置：已安装 dsh（`dsh --version` 能输出版本，本插件已核对 0.1.0-rc.6 / rc.7 / rc.8，并在 0.1.1-rc.2 完成真实视觉迁移），并有一个可跑的 web profile（跑过一次 `dsh web` 即会自动初始化）。
 
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.7
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.8
 ```
 
 发生了什么（不用手动干预）：

--- a/lib/command.js
+++ b/lib/command.js
@@ -112,14 +112,33 @@ function usage(presets, current) {
         '排查：/bridge --doctor',
     ].join('\n');
 }
+function commandMetadata(lang) {
+    if (lang === 'en') {
+        return {
+            description: 'Migrate this session to another tool preset while keeping the original untouched',
+            hint: '<preset> [--go] [--continue] | --doctor',
+        };
+    }
+    if (lang === 'zh') {
+        return {
+            description: '把这个会话迁移到另一工具 preset，原会话保持不动',
+            hint: '<模式> [--go] [--continue] | --doctor',
+        };
+    }
+    return {
+        description: 'Migrate across tool presets; keep the original untouched · 跨 preset 迁移会话，原会话保持不动',
+        hint: '<preset/模式> [--go] [--continue] | --doctor',
+    };
+}
 /** 建一个 `/bridge` 命令定义。返回值形状对齐上游 `CommandDefinition`。 */
 export function createBridgeCommand(deps) {
     const pending = new Map();
     const now = deps.now ?? (() => Date.now());
+    const metadata = commandMetadata(deps.config.lang);
     return {
         name: 'bridge',
-        description: '把这个会话迁移到另一个工具模式（preset），原会话保持不动',
-        input: { hint: '<preset> [--go] [--continue] | --doctor' },
+        description: metadata.description,
+        input: { hint: metadata.hint },
         handler: async (invocation) => {
             const sessionId = invocation.agent?.session?.id ?? invocation.agent?.session?.header?.id;
             if (!sessionId)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-plugin-bridge",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-plugin-bridge",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-plugin-bridge",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "DeepSeek Harness Cordis bundle for cross-preset session migration via fixed-schema handoff summaries",
   "type": "module",
   "main": "lib/index.js",

--- a/src/command.ts
+++ b/src/command.ts
@@ -176,6 +176,25 @@ function usage(presets: PresetRow[], current: string | undefined): string {
   ].join('\n');
 }
 
+function commandMetadata(lang: Lang): { description: string; hint: string } {
+  if (lang === 'en') {
+    return {
+      description: 'Migrate this session to another tool preset while keeping the original untouched',
+      hint: '<preset> [--go] [--continue] | --doctor',
+    };
+  }
+  if (lang === 'zh') {
+    return {
+      description: '把这个会话迁移到另一工具 preset，原会话保持不动',
+      hint: '<模式> [--go] [--continue] | --doctor',
+    };
+  }
+  return {
+    description: 'Migrate across tool presets; keep the original untouched · 跨 preset 迁移会话，原会话保持不动',
+    hint: '<preset/模式> [--go] [--continue] | --doctor',
+  };
+}
+
 /** 建一个 `/bridge` 命令定义。返回值形状对齐上游 `CommandDefinition`。 */
 export function createBridgeCommand(deps: BridgeCommandDeps): {
   name: string;
@@ -185,11 +204,12 @@ export function createBridgeCommand(deps: BridgeCommandDeps): {
 } {
   const pending = new Map<string, Pending>();
   const now = deps.now ?? (() => Date.now());
+  const metadata = commandMetadata(deps.config.lang);
 
   return {
     name: 'bridge',
-    description: '把这个会话迁移到另一个工具模式（preset），原会话保持不动',
-    input: { hint: '<preset> [--go] [--continue] | --doctor' },
+    description: metadata.description,
+    input: { hint: metadata.hint },
     handler: async (invocation: BridgeInvocation): Promise<BridgeResult> => {
       const sessionId = invocation.agent?.session?.id ?? invocation.agent?.session?.header?.id;
       if (!sessionId) return { kind: 'error', text: '取不到当前会话身份，无法迁移。' };

--- a/test/command.test.mjs
+++ b/test/command.test.mjs
@@ -54,6 +54,24 @@ test('命令定义形状符合上游 CommandDefinition', () => {
   assert.ok(command.input.hint.includes('--doctor'), '自检入口要出现在提示里');
 });
 
+test('命令列表文案跟随 lang，auto 默认用单行双语', () => {
+  const auto = setup({}, { lang: 'auto' }).command;
+  assert.match(auto.description, /Migrate across tool presets/);
+  assert.match(auto.description, /跨 preset 迁移会话/);
+  assert.equal(auto.description.includes('\n'), false);
+  assert.match(auto.input.hint, /preset\/模式/);
+
+  const en = setup({}, { lang: 'en' }).command;
+  assert.match(en.description, /^Migrate this session/);
+  assert.doesNotMatch(en.description, /[\u3400-\u9fff]/u);
+  assert.match(en.input.hint, /^<preset>/);
+
+  const zh = setup({}, { lang: 'zh' }).command;
+  assert.match(zh.description, /^把这个会话迁移/);
+  assert.doesNotMatch(zh.description, /Migrate/);
+  assert.match(zh.input.hint, /^<模式>/);
+});
+
 test('/bridge 不带参数：列出可迁入的模式与当前模式', async () => {
   const { invoke } = setup();
   const result = await invoke('');


### PR DESCRIPTION
## Summary

- make `/bridge` command-list metadata follow the existing `lang` config
- show a compact one-line English/Chinese description for the default `auto` mode
- localize both the description and input hint for explicit `en` and `zh` modes
- bump the installable patch version to v0.2.8

## Verification

- `npm test` — 124/124 passed
- `npm run pack:check` — v0.2.8 package assembled successfully