### PR TITLE
feat: localize /bridge command output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Move a produced DeepSeek Harness session to another tool preset through a previe
 ## Quick start
 
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.8
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.9
 # restart dsh web once
 ```
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,7 +20,7 @@
 ## 快速开始
 
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.8
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.9
 # 重启一次 dsh web
 ```
 

--- a/docs/guide.zh.md
+++ b/docs/guide.zh.md
@@ -7,7 +7,7 @@
 前置：已安装 dsh（`dsh --version` 能输出版本，本插件已核对 0.1.0-rc.6 / rc.7 / rc.8，并在 0.1.1-rc.2 完成真实视觉迁移），并有一个可跑的 web profile（跑过一次 `dsh web` 即会自动初始化）。
 
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.8
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.9
 ```
 
 发生了什么（不用手动干预）：

--- a/lib/command.js
+++ b/lib/command.js
@@ -97,8 +97,25 @@ export function parseBridgeInput(rawInput) {
     }
     return out;
 }
-function usage(presets, current) {
+function displayLang(lang) {
+    return lang === 'en' ? 'en' : 'zh';
+}
+function usage(presets, current, lang) {
     const targets = presets.filter((p) => p.id !== current).map((p) => p.id);
+    if (lang === 'en') {
+        return [
+            'Usage:',
+            '  /bridge <preset>          Preview a handoff without changing either session',
+            '  /bridge <preset> --go     Migrate after review; the new session restates and waits',
+            '  /bridge <preset> --go --continue  Restate and continue in the same model request',
+            '',
+            `Available: ${targets.length ? targets.join(' · ') : '(no other presets in this deployment)'}`,
+            ...(current ? [`Current: ${current}`] : []),
+            '',
+            'Options: --continue · --tier flash|current|pro · --lang zh|en|auto · --goal-rounds N · --file <edited-summary>',
+            'Check: /bridge --doctor',
+        ].join('\n');
+    }
     return [
         '用法：',
         '  /bridge <模式>          生成交接摘要给你过目（不改动任何会话）',
@@ -144,8 +161,13 @@ export function createBridgeCommand(deps) {
             if (!sessionId)
                 return { kind: 'error', text: '取不到当前会话身份，无法迁移。' };
             const parsed = parseBridgeInput(invocation.rawInput ?? '');
-            if (parsed.error)
-                return { kind: 'error', text: `${parsed.error}\n\n${''}用 /bridge 看用法。` };
+            const initialLang = displayLang(parsed.lang ?? deps.config.lang);
+            if (parsed.error) {
+                return {
+                    kind: 'error',
+                    text: initialLang === 'en' ? `${parsed.error}\n\nUse /bridge to see the available syntax.` : `${parsed.error}\n\n用 /bridge 看用法。`,
+                };
+            }
             const rpc = deps.rpcFor(invocation.signal);
             const config = deps.config;
             let presets;
@@ -160,60 +182,85 @@ export function createBridgeCommand(deps) {
             if (parsed.doctor) {
                 const probes = deps.probe?.() ?? [];
                 const missing = probes.filter((probe) => !probe.available).map((probe) => probe.method);
-                const lines = [
-                    `网关：进程内 ctx.apiProxy · ${probes.length - missing.length}/${probes.length} 个方法可用`,
-                    `当前模式：${current ?? '（读不到）'}`,
-                    `可迁入：${presets.filter((p) => p.id !== current).map((p) => p.id).join(' · ') || '（无）'}`,
-                    `配置：档位 ${config.modelTier} · 取材 ${config.sourceCharBudget} 字符 · 摘要 ${config.summaryCharBudget} 字符`
-                        + ` · goal ${config.goalRounds} 轮 · 注入 ${config.inject}`,
-                ];
+                const available = presets.filter((p) => p.id !== current).map((p) => p.id).join(' · ');
+                const lines = initialLang === 'en'
+                    ? [
+                        `Gateway: in-process ctx.apiProxy · ${probes.length - missing.length}/${probes.length} methods available`,
+                        `Current preset: ${current ?? '(unavailable)'}`,
+                        `Available targets: ${available || '(none)'}`,
+                        `Config: tier ${config.modelTier} · source ${config.sourceCharBudget} chars · summary ${config.summaryCharBudget} chars`
+                            + ` · goal ${config.goalRounds} rounds · injection ${config.inject}`,
+                    ]
+                    : [
+                        `网关：进程内 ctx.apiProxy · ${probes.length - missing.length}/${probes.length} 个方法可用`,
+                        `当前模式：${current ?? '（读不到）'}`,
+                        `可迁入：${available || '（无）'}`,
+                        `配置：档位 ${config.modelTier} · 取材 ${config.sourceCharBudget} 字符 · 摘要 ${config.summaryCharBudget} 字符`
+                            + ` · goal ${config.goalRounds} 轮 · 注入 ${config.inject}`,
+                    ];
                 if (missing.length) {
                     lines.push('');
-                    lines.push(`⚠ 缺少：${missing.join(', ')}`);
-                    lines.push('这套 host 的网关面和插件预期的不一致（上游是 developer preview，接口会变）。');
-                    lines.push('请到 https://github.com/Totoro-qaq/dsh-plugin-bridge/issues 报一下你的 dsh 版本。');
+                    if (initialLang === 'en') {
+                        lines.push(`⚠ Missing: ${missing.join(', ')}`);
+                        lines.push('This host gateway does not match the plugin contract; the upstream API is still a developer preview.');
+                        lines.push('Report your dsh version at https://github.com/Totoro-qaq/dsh-plugin-bridge/issues.');
+                    }
+                    else {
+                        lines.push(`⚠ 缺少：${missing.join(', ')}`);
+                        lines.push('这套 host 的网关面和插件预期的不一致（上游是 developer preview，接口会变）。');
+                        lines.push('请到 https://github.com/Totoro-qaq/dsh-plugin-bridge/issues 报一下你的 dsh 版本。');
+                    }
                     return { kind: 'error', text: lines.join('\n') };
                 }
                 return { kind: 'success', text: lines.join('\n') };
             }
             if (parsed.help || !parsed.preset)
-                return { kind: 'success', text: usage(presets, current) };
+                return { kind: 'success', text: usage(presets, current, initialLang) };
             const target = parsed.preset;
             if (!presets.some((p) => p.id === target)) {
                 return {
                     kind: 'error',
-                    text: `没有叫 "${target}" 的模式（或者它当前是坏的）。\n\n${usage(presets, current)}`,
+                    text: initialLang === 'en'
+                        ? `No usable preset named "${target}".\n\n${usage(presets, current, initialLang)}`
+                        : `没有叫 "${target}" 的模式（或者它当前是坏的）。\n\n${usage(presets, current, initialLang)}`,
                 };
             }
-            if (target === current)
-                return { kind: 'error', text: `这个会话已经在 ${target} 模式了。` };
+            if (target === current) {
+                return { kind: 'error', text: initialLang === 'en' ? `This session already uses the ${target} preset.` : `这个会话已经在 ${target} 模式了。` };
+            }
             /* ---------------- 执行 ---------------- */
             if (parsed.go) {
                 let summary;
-                let source = '暂存的预览';
+                let pendingLang;
                 if (parsed.file) {
                     try {
                         summary = deps.readSummary?.(parsed.file);
-                        source = parsed.file;
                     }
                     catch (error) {
-                        return { kind: 'error', text: `读不到 ${parsed.file}：${describe(error)}` };
+                        return { kind: 'error', text: initialLang === 'en' ? `Cannot read ${parsed.file}: ${describe(error)}` : `读不到 ${parsed.file}：${describe(error)}` };
                     }
                 }
                 else {
                     const stashed = pending.get(sessionId);
-                    if (stashed && stashed.preset === target && now() - stashed.at < PENDING_TTL_MS)
+                    if (stashed && stashed.preset === target && now() - stashed.at < PENDING_TTL_MS) {
                         summary = stashed.summary;
+                        pendingLang = stashed.lang;
+                    }
                 }
+                const runLang = parsed.lang === 'en' || parsed.lang === 'zh' ? parsed.lang : pendingLang ?? initialLang;
+                const source = parsed.file ?? (runLang === 'en' ? 'the reviewed preview' : '暂存的预览');
                 if (!summary?.trim()) {
                     return {
                         kind: 'error',
-                        text: `没有可用的摘要（预览可能已过期）。先跑 /bridge ${target} 看一眼，确认后再 --go。`,
+                        text: runLang === 'en'
+                            ? `No usable handoff is available; the preview may have expired. Run /bridge ${target}, review it, then add --go.`
+                            : `没有可用的摘要（预览可能已过期）。先跑 /bridge ${target} 看一眼，确认后再 --go。`,
                     };
                 }
                 try {
                     const row = await findSession(rpc, sessionId).catch(() => undefined);
-                    const targetTitle = migratedTitle(titleOf(row), target);
+                    const sourceTitle = titleOf(row);
+                    const targetTitle = sourceTitle ? migratedTitle(sourceTitle, target) : (runLang === 'en' ? `Migrated to ${target}` : migratedTitle(sourceTitle, target));
                     const result = await executeMigration(rpc, {
                         sessionId,
                         to: target,
@@ -222,21 +269,35 @@ export function createBridgeCommand(deps) {
                         inject: parsed.inject ?? config.inject,
                         title: targetTitle,
                         autoContinue: parsed.autoContinue,
-                        ...(parsed.lang && parsed.lang !== 'auto' ? { lang: parsed.lang } : {}),
+                        lang: runLang,
                     });
                     pending.delete(sessionId);
-                    const lines = [
-                        `已在 ${result.agentPreset} 模式下建好新会话，摘要来自${source}。`,
-                        `目标会话：${targetTitle} · ${result.sessionId}`,
-                        result.kickoffSent
-                            ? (parsed.autoContinue
-                                ? '交接目标已暂停；新会话会在同一轮复述理解并继续下一步，不触发额外 goal 轮次。'
-                                : '新会话只会复述理解，然后暂停等待你确认。')
-                            : '新会话没有自动启动；请按下面的警告检查后手动继续。',
-                        '原会话原封不动，随时点回来；新会话不满意就归档。',
-                    ];
-                    if (result.imagesSent)
-                        lines.push(`图片：${result.imagesSent} 张尚未解析的原图已随 kickoff 搬到视觉目标。`);
+                    const lines = runLang === 'en'
+                        ? [
+                            `Created a new session in the ${result.agentPreset} preset from ${source}.`,
+                            `Target session: ${targetTitle} · ${result.sessionId}`,
+                            result.kickoffSent
+                                ? (parsed.autoContinue
+                                    ? 'The handoff goal is paused; the new session will restate and continue in the same request without an extra goal round.'
+                                    : 'The new session will only restate the handoff, then wait for your confirmation.')
+                                : 'The new session did not start automatically; inspect the warnings below before continuing manually.',
+                            'The source session is untouched and remains available; archive the target if the handoff is unsatisfactory.',
+                        ]
+                        : [
+                            `已在 ${result.agentPreset} 模式下建好新会话，摘要来自${source}。`,
+                            `目标会话：${targetTitle} · ${result.sessionId}`,
+                            result.kickoffSent
+                                ? (parsed.autoContinue
+                                    ? '交接目标已暂停；新会话会在同一轮复述理解并继续下一步，不触发额外 goal 轮次。'
+                                    : '新会话只会复述理解，然后暂停等待你确认。')
+                                : '新会话没有自动启动；请按下面的警告检查后手动继续。',
+                            '原会话原封不动，随时点回来；新会话不满意就归档。',
+                        ];
+                    if (result.imagesSent) {
+                        lines.push(runLang === 'en'
+                            ? `Images: ${result.imagesSent} unresolved source image(s) were attached to the vision target kickoff.`
+                            : `图片：${result.imagesSent} 张尚未解析的原图已随 kickoff 搬到视觉目标。`);
+                    }
                     for (const warning of result.warnings)
                         lines.push(`⚠ ${warning}`);
                     return { kind: 'success', text: lines.join('\n') };
@@ -260,28 +321,47 @@ export function createBridgeCommand(deps) {
                     ...(config.workerModel ? { model: config.workerModel } : {}),
                 });
                 const file = deps.writeSummary?.(sessionId, preview.summary);
-                pending.set(sessionId, { preset: target, summary: preview.summary, at: now(), ...(file ? { file } : {}) });
+                pending.set(sessionId, { preset: target, summary: preview.summary, lang: preview.lang, at: now(), ...(file ? { file } : {}) });
                 const s = preview.source;
-                const lines = [
-                    `─── 交接摘要 · ${current ?? '当前模式'} → ${target}（请过目，重点看数字与路径）───`,
-                    preview.summary,
-                    '───────────────────────────────────────────',
-                    `取材 ${s.text.length} 字符 · 用户消息 ${s.userMessagesUsed}/${s.userMessagesTotal} 条`
-                        + `${s.reusedCompaction ? ' · 复用了 compaction 底稿' : ''}`
-                        + ` · 压缩模型 ${preview.worker.model || '（会话默认）'} · 用时 ${Math.round((now() - startedAt) / 1000)}s`,
-                ];
+                const outputLang = preview.lang;
+                const lines = outputLang === 'en'
+                    ? [
+                        `─── Handoff · ${current ?? 'current preset'} → ${target} (review numbers and paths) ───`,
+                        preview.summary,
+                        '───────────────────────────────────────────',
+                        `Source ${s.text.length} chars · user messages ${s.userMessagesUsed}/${s.userMessagesTotal}`
+                            + `${s.reusedCompaction ? ' · reused compaction' : ''}`
+                            + ` · worker ${preview.worker.model || '(session default)'} · ${Math.round((now() - startedAt) / 1000)}s`,
+                    ]
+                    : [
+                        `─── 交接摘要 · ${current ?? '当前模式'} → ${target}（请过目，重点看数字与路径）───`,
+                        preview.summary,
+                        '───────────────────────────────────────────',
+                        `取材 ${s.text.length} 字符 · 用户消息 ${s.userMessagesUsed}/${s.userMessagesTotal} 条`
+                            + `${s.reusedCompaction ? ' · 复用了 compaction 底稿' : ''}`
+                            + ` · 压缩模型 ${preview.worker.model || '（会话默认）'} · 用时 ${Math.round((now() - startedAt) / 1000)}s`,
+                    ];
                 if (s.visualEvidence.images) {
-                    lines.push(`图片 ${s.visualEvidence.images} 张 / ${s.visualEvidence.imageMessages} 条消息`
-                        + ` · 有关联原文 ${s.visualEvidence.represented} 条 · 未解析 ${s.visualEvidence.unresolved} 条`);
+                    lines.push(outputLang === 'en'
+                        ? `Images ${s.visualEvidence.images} / ${s.visualEvidence.imageMessages} messages`
+                            + ` · represented ${s.visualEvidence.represented} · unresolved ${s.visualEvidence.unresolved}`
+                        : `图片 ${s.visualEvidence.images} 张 / ${s.visualEvidence.imageMessages} 条消息`
+                            + ` · 有关联原文 ${s.visualEvidence.represented} 条 · 未解析 ${s.visualEvidence.unresolved} 条`);
                 }
-                if (s.truncated)
-                    lines.push(`⚠ 取材因预算被裁剪（${s.dropped.join(' / ')}），摘要是基于被裁过的历史写的`);
+                if (s.truncated) {
+                    lines.push(outputLang === 'en'
+                        ? `⚠ Source material was truncated by budget (${s.dropped.join(' / ')}); this handoff reflects the bounded history.`
+                        : `⚠ 取材因预算被裁剪（${s.dropped.join(' / ')}），摘要是基于被裁过的历史写的`);
+                }
                 if (preview.capped)
-                    lines.push('⚠ 压缩工人超时被取消，摘要按已产出文本计');
+                    lines.push(outputLang === 'en' ? '⚠ The summary worker timed out; the handoff uses the text produced before cancellation.' : '⚠ 压缩工人超时被取消，摘要按已产出文本计');
                 lines.push('');
-                lines.push(`没问题就执行：/bridge ${target} --go`);
-                if (file)
-                    lines.push(`要改：编辑 ${file} 之后 /bridge ${target} --go --file ${file}`);
+                lines.push(outputLang === 'en' ? `Review and run: /bridge ${target} --go` : `没问题就执行：/bridge ${target} --go`);
+                if (file) {
+                    lines.push(outputLang === 'en'
+                        ? `Edit first: update ${file}, then run /bridge ${target} --go --file ${file}`
+                        : `要改：编辑 ${file} 之后 /bridge ${target} --go --file ${file}`);
+                }
                 return { kind: 'success', text: lines.join('\n') };
             }
             catch (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-plugin-bridge",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-plugin-bridge",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-plugin-bridge",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "DeepSeek Harness Cordis bundle for cross-preset session migration via fixed-schema handoff summaries",
   "type": "module",
   "main": "lib/index.js",

--- a/src/command.ts
+++ b/src/command.ts
@@ -74,6 +74,7 @@ export interface BridgeCommandDeps {
 interface Pending {
   preset: string;
   summary: string;
+  lang: 'zh' | 'en';
   file?: string;
   at: number;
 }
@@ -160,8 +161,28 @@ export function parseBridgeInput(rawInput: string): ParsedInput {
   return out;
 }
 
-function usage(presets: PresetRow[], current: string | undefined): string {
+type DisplayLang = 'zh' | 'en';
+
+function displayLang(lang: Lang | undefined): DisplayLang {
+  return lang === 'en' ? 'en' : 'zh';
+}
+
+function usage(presets: PresetRow[], current: string | undefined, lang: DisplayLang): string {
   const targets = presets.filter((p) => p.id !== current).map((p) => p.id);
+  if (lang === 'en') {
+    return [
+      'Usage:',
+      '  /bridge <preset>          Preview a handoff without changing either session',
+      '  /bridge <preset> --go     Migrate after review; the new session restates and waits',
+      '  /bridge <preset> --go --continue  Restate and continue in the same model request',
+      '',
+      `Available: ${targets.length ? targets.join(' · ') : '(no other presets in this deployment)'}`,
+      ...(current ? [`Current: ${current}`] : []),
+      '',
+      'Options: --continue · --tier flash|current|pro · --lang zh|en|auto · --goal-rounds N · --file <edited-summary>',
+      'Check: /bridge --doctor',
+    ].join('\n');
+  }
   return [
     '用法：',
     '  /bridge <模式>          生成交接摘要给你过目（不改动任何会话）',
@@ -215,7 +236,13 @@ export function createBridgeCommand(deps: BridgeCommandDeps): {
       if (!sessionId) return { kind: 'error', text: '取不到当前会话身份，无法迁移。' };
 
       const parsed = parseBridgeInput(invocation.rawInput ?? '');
-      if (parsed.error) return { kind: 'error', text: `${parsed.error}\n\n${''}用 /bridge 看用法。` };
+      const initialLang = displayLang(parsed.lang ?? deps.config.lang);
+      if (parsed.error) {
+        return {
+          kind: 'error',
+          text: initialLang === 'en' ? `${parsed.error}\n\nUse /bridge to see the available syntax.` : `${parsed.error}\n\n用 /bridge 看用法。`,
+        };
+      }
 
       const rpc = deps.rpcFor(invocation.signal);
       const config = deps.config;
@@ -232,58 +259,84 @@ export function createBridgeCommand(deps: BridgeCommandDeps): {
       if (parsed.doctor) {
         const probes = deps.probe?.() ?? [];
         const missing = probes.filter((probe) => !probe.available).map((probe) => probe.method);
-        const lines = [
-          `网关：进程内 ctx.apiProxy · ${probes.length - missing.length}/${probes.length} 个方法可用`,
-          `当前模式：${current ?? '（读不到）'}`,
-          `可迁入：${presets.filter((p) => p.id !== current).map((p) => p.id).join(' · ') || '（无）'}`,
-          `配置：档位 ${config.modelTier} · 取材 ${config.sourceCharBudget} 字符 · 摘要 ${config.summaryCharBudget} 字符`
-          + ` · goal ${config.goalRounds} 轮 · 注入 ${config.inject}`,
-        ];
+        const available = presets.filter((p) => p.id !== current).map((p) => p.id).join(' · ');
+        const lines = initialLang === 'en'
+          ? [
+              `Gateway: in-process ctx.apiProxy · ${probes.length - missing.length}/${probes.length} methods available`,
+              `Current preset: ${current ?? '(unavailable)'}`,
+              `Available targets: ${available || '(none)'}`,
+              `Config: tier ${config.modelTier} · source ${config.sourceCharBudget} chars · summary ${config.summaryCharBudget} chars`
+              + ` · goal ${config.goalRounds} rounds · injection ${config.inject}`,
+            ]
+          : [
+              `网关：进程内 ctx.apiProxy · ${probes.length - missing.length}/${probes.length} 个方法可用`,
+              `当前模式：${current ?? '（读不到）'}`,
+              `可迁入：${available || '（无）'}`,
+              `配置：档位 ${config.modelTier} · 取材 ${config.sourceCharBudget} 字符 · 摘要 ${config.summaryCharBudget} 字符`
+              + ` · goal ${config.goalRounds} 轮 · 注入 ${config.inject}`,
+            ];
         if (missing.length) {
           lines.push('');
-          lines.push(`⚠ 缺少：${missing.join(', ')}`);
-          lines.push('这套 host 的网关面和插件预期的不一致（上游是 developer preview，接口会变）。');
-          lines.push('请到 https://github.com/Totoro-qaq/dsh-plugin-bridge/issues 报一下你的 dsh 版本。');
+          if (initialLang === 'en') {
+            lines.push(`⚠ Missing: ${missing.join(', ')}`);
+            lines.push('This host gateway does not match the plugin contract; the upstream API is still a developer preview.');
+            lines.push('Report your dsh version at https://github.com/Totoro-qaq/dsh-plugin-bridge/issues.');
+          } else {
+            lines.push(`⚠ 缺少：${missing.join(', ')}`);
+            lines.push('这套 host 的网关面和插件预期的不一致（上游是 developer preview，接口会变）。');
+            lines.push('请到 https://github.com/Totoro-qaq/dsh-plugin-bridge/issues 报一下你的 dsh 版本。');
+          }
           return { kind: 'error', text: lines.join('\n') };
         }
         return { kind: 'success', text: lines.join('\n') };
       }
 
-      if (parsed.help || !parsed.preset) return { kind: 'success', text: usage(presets, current) };
+      if (parsed.help || !parsed.preset) return { kind: 'success', text: usage(presets, current, initialLang) };
 
       const target = parsed.preset;
       if (!presets.some((p) => p.id === target)) {
         return {
           kind: 'error',
-          text: `没有叫 "${target}" 的模式（或者它当前是坏的）。\n\n${usage(presets, current)}`,
+          text: initialLang === 'en'
+            ? `No usable preset named "${target}".\n\n${usage(presets, current, initialLang)}`
+            : `没有叫 "${target}" 的模式（或者它当前是坏的）。\n\n${usage(presets, current, initialLang)}`,
         };
       }
-      if (target === current) return { kind: 'error', text: `这个会话已经在 ${target} 模式了。` };
+      if (target === current) {
+        return { kind: 'error', text: initialLang === 'en' ? `This session already uses the ${target} preset.` : `这个会话已经在 ${target} 模式了。` };
+      }
 
       /* ---------------- 执行 ---------------- */
       if (parsed.go) {
         let summary: string | undefined;
-        let source = '暂存的预览';
+        let pendingLang: DisplayLang | undefined;
         if (parsed.file) {
           try {
             summary = deps.readSummary?.(parsed.file);
-            source = parsed.file;
           } catch (error) {
-            return { kind: 'error', text: `读不到 ${parsed.file}：${describe(error)}` };
+            return { kind: 'error', text: initialLang === 'en' ? `Cannot read ${parsed.file}: ${describe(error)}` : `读不到 ${parsed.file}：${describe(error)}` };
           }
         } else {
           const stashed = pending.get(sessionId);
-          if (stashed && stashed.preset === target && now() - stashed.at < PENDING_TTL_MS) summary = stashed.summary;
+          if (stashed && stashed.preset === target && now() - stashed.at < PENDING_TTL_MS) {
+            summary = stashed.summary;
+            pendingLang = stashed.lang;
+          }
         }
+        const runLang = parsed.lang === 'en' || parsed.lang === 'zh' ? parsed.lang : pendingLang ?? initialLang;
+        const source = parsed.file ?? (runLang === 'en' ? 'the reviewed preview' : '暂存的预览');
         if (!summary?.trim()) {
           return {
             kind: 'error',
-            text: `没有可用的摘要（预览可能已过期）。先跑 /bridge ${target} 看一眼，确认后再 --go。`,
+            text: runLang === 'en'
+              ? `No usable handoff is available; the preview may have expired. Run /bridge ${target}, review it, then add --go.`
+              : `没有可用的摘要（预览可能已过期）。先跑 /bridge ${target} 看一眼，确认后再 --go。`,
           };
         }
         try {
           const row = await findSession(rpc, sessionId).catch(() => undefined);
-          const targetTitle = migratedTitle(titleOf(row), target);
+          const sourceTitle = titleOf(row);
+          const targetTitle = sourceTitle ? migratedTitle(sourceTitle, target) : (runLang === 'en' ? `Migrated to ${target}` : migratedTitle(sourceTitle, target));
           const result = await executeMigration(rpc, {
             sessionId,
             to: target,
@@ -292,20 +345,35 @@ export function createBridgeCommand(deps: BridgeCommandDeps): {
             inject: parsed.inject ?? config.inject,
             title: targetTitle,
             autoContinue: parsed.autoContinue,
-            ...(parsed.lang && parsed.lang !== 'auto' ? { lang: parsed.lang } : {}),
+            lang: runLang,
           });
           pending.delete(sessionId);
-          const lines = [
-            `已在 ${result.agentPreset} 模式下建好新会话，摘要来自${source}。`,
-            `目标会话：${targetTitle} · ${result.sessionId}`,
-            result.kickoffSent
-              ? (parsed.autoContinue
-                  ? '交接目标已暂停；新会话会在同一轮复述理解并继续下一步，不触发额外 goal 轮次。'
-                  : '新会话只会复述理解，然后暂停等待你确认。')
-              : '新会话没有自动启动；请按下面的警告检查后手动继续。',
-            '原会话原封不动，随时点回来；新会话不满意就归档。',
-          ];
-          if (result.imagesSent) lines.push(`图片：${result.imagesSent} 张尚未解析的原图已随 kickoff 搬到视觉目标。`);
+          const lines = runLang === 'en'
+            ? [
+                `Created a new session in the ${result.agentPreset} preset from ${source}.`,
+                `Target session: ${targetTitle} · ${result.sessionId}`,
+                result.kickoffSent
+                  ? (parsed.autoContinue
+                      ? 'The handoff goal is paused; the new session will restate and continue in the same request without an extra goal round.'
+                      : 'The new session will only restate the handoff, then wait for your confirmation.')
+                  : 'The new session did not start automatically; inspect the warnings below before continuing manually.',
+                'The source session is untouched and remains available; archive the target if the handoff is unsatisfactory.',
+              ]
+            : [
+                `已在 ${result.agentPreset} 模式下建好新会话，摘要来自${source}。`,
+                `目标会话：${targetTitle} · ${result.sessionId}`,
+                result.kickoffSent
+                  ? (parsed.autoContinue
+                      ? '交接目标已暂停；新会话会在同一轮复述理解并继续下一步，不触发额外 goal 轮次。'
+                      : '新会话只会复述理解，然后暂停等待你确认。')
+                  : '新会话没有自动启动；请按下面的警告检查后手动继续。',
+                '原会话原封不动，随时点回来；新会话不满意就归档。',
+              ];
+          if (result.imagesSent) {
+            lines.push(runLang === 'en'
+              ? `Images: ${result.imagesSent} unresolved source image(s) were attached to the vision target kickoff.`
+              : `图片：${result.imagesSent} 张尚未解析的原图已随 kickoff 搬到视觉目标。`);
+          }
           for (const warning of result.warnings) lines.push(`⚠ ${warning}`);
           return { kind: 'success', text: lines.join('\n') };
         } catch (error) {
@@ -328,26 +396,47 @@ export function createBridgeCommand(deps: BridgeCommandDeps): {
           ...(config.workerModel ? { model: config.workerModel } : {}),
         });
         const file = deps.writeSummary?.(sessionId, preview.summary);
-        pending.set(sessionId, { preset: target, summary: preview.summary, at: now(), ...(file ? { file } : {}) });
+        pending.set(sessionId, { preset: target, summary: preview.summary, lang: preview.lang, at: now(), ...(file ? { file } : {}) });
 
         const s = preview.source;
-        const lines = [
-          `─── 交接摘要 · ${current ?? '当前模式'} → ${target}（请过目，重点看数字与路径）───`,
-          preview.summary,
-          '───────────────────────────────────────────',
-          `取材 ${s.text.length} 字符 · 用户消息 ${s.userMessagesUsed}/${s.userMessagesTotal} 条`
-          + `${s.reusedCompaction ? ' · 复用了 compaction 底稿' : ''}`
-          + ` · 压缩模型 ${preview.worker.model || '（会话默认）'} · 用时 ${Math.round((now() - startedAt) / 1000)}s`,
-        ];
+        const outputLang = preview.lang;
+        const lines = outputLang === 'en'
+          ? [
+              `─── Handoff · ${current ?? 'current preset'} → ${target} (review numbers and paths) ───`,
+              preview.summary,
+              '───────────────────────────────────────────',
+              `Source ${s.text.length} chars · user messages ${s.userMessagesUsed}/${s.userMessagesTotal}`
+              + `${s.reusedCompaction ? ' · reused compaction' : ''}`
+              + ` · worker ${preview.worker.model || '(session default)'} · ${Math.round((now() - startedAt) / 1000)}s`,
+            ]
+          : [
+              `─── 交接摘要 · ${current ?? '当前模式'} → ${target}（请过目，重点看数字与路径）───`,
+              preview.summary,
+              '───────────────────────────────────────────',
+              `取材 ${s.text.length} 字符 · 用户消息 ${s.userMessagesUsed}/${s.userMessagesTotal} 条`
+              + `${s.reusedCompaction ? ' · 复用了 compaction 底稿' : ''}`
+              + ` · 压缩模型 ${preview.worker.model || '（会话默认）'} · 用时 ${Math.round((now() - startedAt) / 1000)}s`,
+            ];
         if (s.visualEvidence.images) {
-          lines.push(`图片 ${s.visualEvidence.images} 张 / ${s.visualEvidence.imageMessages} 条消息`
-            + ` · 有关联原文 ${s.visualEvidence.represented} 条 · 未解析 ${s.visualEvidence.unresolved} 条`);
+          lines.push(outputLang === 'en'
+            ? `Images ${s.visualEvidence.images} / ${s.visualEvidence.imageMessages} messages`
+              + ` · represented ${s.visualEvidence.represented} · unresolved ${s.visualEvidence.unresolved}`
+            : `图片 ${s.visualEvidence.images} 张 / ${s.visualEvidence.imageMessages} 条消息`
+              + ` · 有关联原文 ${s.visualEvidence.represented} 条 · 未解析 ${s.visualEvidence.unresolved} 条`);
         }
-        if (s.truncated) lines.push(`⚠ 取材因预算被裁剪（${s.dropped.join(' / ')}），摘要是基于被裁过的历史写的`);
-        if (preview.capped) lines.push('⚠ 压缩工人超时被取消，摘要按已产出文本计');
+        if (s.truncated) {
+          lines.push(outputLang === 'en'
+            ? `⚠ Source material was truncated by budget (${s.dropped.join(' / ')}); this handoff reflects the bounded history.`
+            : `⚠ 取材因预算被裁剪（${s.dropped.join(' / ')}），摘要是基于被裁过的历史写的`);
+        }
+        if (preview.capped) lines.push(outputLang === 'en' ? '⚠ The summary worker timed out; the handoff uses the text produced before cancellation.' : '⚠ 压缩工人超时被取消，摘要按已产出文本计');
         lines.push('');
-        lines.push(`没问题就执行：/bridge ${target} --go`);
-        if (file) lines.push(`要改：编辑 ${file} 之后 /bridge ${target} --go --file ${file}`);
+        lines.push(outputLang === 'en' ? `Review and run: /bridge ${target} --go` : `没问题就执行：/bridge ${target} --go`);
+        if (file) {
+          lines.push(outputLang === 'en'
+            ? `Edit first: update ${file}, then run /bridge ${target} --go --file ${file}`
+            : `要改：编辑 ${file} 之后 /bridge ${target} --go --file ${file}`);
+        }
         return { kind: 'success', text: lines.join('\n') };
       } catch (error) {
         return { kind: 'error', text: describe(error) };

--- a/test/command.test.mjs
+++ b/test/command.test.mjs
@@ -95,6 +95,21 @@ test('/bridge code：出摘要、落盘、给出确认命令，且不动任何�
   assert.equal(host.state.archived.length, 1, '工人用完即归档');
 });
 
+test('/bridge --lang en：预览与确认正文全程英文，并由暂存预览继承语言', async () => {
+  const { invoke } = setup();
+  const preview = await invoke('code --lang en');
+  assert.equal(preview.kind, 'success', preview.text);
+  assert.match(preview.text, /Handoff · minimal → code/);
+  assert.match(preview.text, /Review and run: \/bridge code --go/);
+  assert.doesNotMatch(preview.text, /交接摘要|没问题就执行/);
+
+  const migrated = await invoke('code --go');
+  assert.equal(migrated.kind, 'success', migrated.text);
+  assert.match(migrated.text, /Created a new session in the code preset/);
+  assert.match(migrated.text, /wait for your confirmation/);
+  assert.doesNotMatch(migrated.text, /[\u3400-\u9fff]/u);
+});
+
 test('/bridge code --go：用预览的摘要建目标会话，goal 只给一轮', async () => {
   const { host, invoke } = setup();
   await invoke('code');


### PR DESCRIPTION
## Summary

- localize `/bridge` usage, doctor, preview, confirmation, and happy-path migration output
- preserve the preview language through the later `--go` confirmation
- keep target fallback titles English in English handoffs
- bump the installable patch release to v0.2.9

## Why

A clean official-WebUI English demo exposed that v0.2.8 localized command-list metadata but not the command result body.

## Verification

- `npm test` — 125/125 passed
- `npm run pack:check` — v0.2.9 package assembled successfully