### PR TITLE
release: prepare npm publishing and streamline docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,9 @@ jobs:
           node-version: ${{ matrix.node }}
           cache: npm
       - run: npm ci
-      # npm test = build + typecheck(src+eval) + 单元测试（含对着假 host 的
-      # 迁移全链路与 CLI 端到端，不需要真的 dsh host，也不烧 token）
-      - run: npm test
-      - name: 构建产物与提交同步（git 安装不跑构建，lib/ 必须随源码提交）
-        run: |
-          npm run build
-          git diff --exit-code lib/ || { echo "::error::lib/ 与 src/ 不同步，请本地 npm run build 后提交 lib/"; exit 1; }
-      - name: 校验数据集可解析
-        run: |
-          node -e "for (const f of ['test','validation']) { const d = require('./datasets/' + f + '.json'); if (!d.themes?.length || !d.templates?.plant) throw new Error(f + ' 数据集结构不完整'); } console.log('datasets ok');"
-      - name: npm 包内容检查
-        run: npm run pack:check
+      # One public gate: build + typecheck + fake-host integration tests,
+      # generated-artifact sync, datasets, then install/import the actual tarball.
+      - run: npm run verify
 
   # 聚合闸：分支保护要求的检查名是 `build`，矩阵会把它拆成 build (22)/(24)，
   # 因此用这个与矩阵同结果的汇聚 job 提供字面名为 build 的检查。

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  npm:
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: npm
+      - run: npm ci
+      - run: npm run release:check -- "${{ github.event.release.tag_name }}"
+      - name: Publish to npm when this version is missing
+        shell: bash
+        run: |
+          package_spec="$(node -p "const p=require('./package.json'); p.name + '@' + p.version")"
+          if npm view "$package_spec" version >/dev/null 2>&1; then
+            echo "$package_spec is already on npm; bootstrap release needs no second publish."
+          else
+            npm publish --access public --provenance
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 本文件记录对使用者可见的变化。版本遵循语义化版本。
 
+## 0.2.10 — 2026-08-23
+
+这一版把已有的迁移安全与实测证据收成可发布、可安装、可扫读的产品路径；迁移运行时语义不变。
+
+### 发布与验证
+
+- 新增统一 `npm run verify`：构建、类型检查、125 项 fake-host 测试、生成产物同步、数据集检查，以及真实 npm tarball 的打包、安装和导入 smoke。
+- `prepublishOnly` 复用同一门禁；GitHub Release 发布前校验 tag 与 `package.json` 版本一致。
+- 新增 GitHub OIDC Trusted Publishing 工作流，首次手动 npm 发布并配置 trusted publisher 后，后续 release 不需要长期 npm token。
+- npm 包包含设计说明、关键报告和原始证据，安装命令缩短为 `dsh plugin --profile web add dsh-plugin-bridge`。
+
+### 文档
+
+- 中英 README 首屏改为“使用场景 → 官方 WebUI 证据 → 一行安装”，长篇安全、成本和图片策略下沉到 `docs/design.md`。
+- 增加兼容矩阵与迁移决策表，保留 30/30、60/60、视觉 5/5、token 配对中位数与适用边界。
+- 完成原生 WebUI 迁移卡片可行性验证；确认官方 client module / slot 路径可行，但因 prerelease 版本耦合暂不进入主包。
+
 ## 0.2.6 — 2026-08-21
 
 这一版补齐 DSH 0.1.1-rc.2 的真实视觉迁移链，并阻止摘要 worker 静默改变目标模型。

--- a/README.md
+++ b/README.md
@@ -13,31 +13,40 @@
 
 English | [中文](README.zh.md)
 
-Move a produced DeepSeek Harness session to another tool preset through a previewable, fixed-schema handoff. The original session stays untouched.
+Halfway through a task and need another tool preset? Switching the produced session in place would leave tool history that belongs to the old assembly. Bridge previews a bounded five-part handoff, opens a clean target, and leaves the original session untouched.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/Totoro-qaq/dsh-plugin-bridge/main/assets/bridge-demo.en.gif" width="880" alt="A real Bridge migration in the official DeepSeek Harness WebUI">
 </p>
 
-[Quick start](#quick-start) · [Safety and cost](#safety-and-cost) · [Accuracy](#accuracy) · [How it works](#how-it-works) · [Compatibility](#compatibility-and-limits)
+[Quick start](#quick-start) · [Why Bridge](#why-bridge) · [Evidence](#evidence-at-a-glance) · [Decisions](#migration-decisions) · [Compatibility](#compatibility)
 
 ## Quick start
 
+Install from npm:
+
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.9
+dsh plugin --profile web add dsh-plugin-bridge
 # restart dsh web once
+```
+
+Pinned GitHub fallback:
+
+```bash
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.10
 ```
 
 Then type in the official WebUI:
 
 ```text
-/bridge                       list available target presets
-/bridge code                  preview the handoff; changes nothing
-/bridge code --go             migrate, restate, then wait for confirmation
-/bridge code --go --continue  restate and start work in the same target turn
+/bridge                       list target presets
+/bridge --doctor              check the host contract after a DSH upgrade
+/bridge code                  preview the handoff; change nothing
+/bridge code --go             migrate, restate, then wait
+/bridge code --go --continue  restate and start work in the same target request
 ```
 
-The preview is editable. If a number or path is wrong, edit the printed summary file and run:
+The preview is editable. Correct a number or path in the printed summary file, then run:
 
 ```text
 /bridge code --go --file <path>
@@ -45,173 +54,90 @@ The preview is editable. If a number or path is wrong, edit the printed summary 
 
 Uninstall with `dsh plugin --profile web remove dsh-plugin-bridge`, then restart `dsh web`.
 
-> **Latest live check — DSH 0.1.1-rc.2 (2026-08-21):** isolated install, `/bridge` registration, 13/13 doctor methods, `standard → minimal` preview/migration, source-VLM preservation, and unresolved PNG transfer all passed with `deepseek-v4-flash-vision-exp`. The rc.8 lifecycle/restart baseline remains documented separately.
+## Why Bridge
 
-## Safety and cost
+| Promise | What it means |
+|---|---|
+| **Preview before execution** | `/bridge <preset>` creates no target and changes no source session. Review or edit the five-section handoff first. |
+| **Move state, not tool traces** | Decisions, paths, current state, and next steps move to a clean preset. Incompatible calls from the old tool assembly do not. |
+| **Fail closed** | The target goal is paused before kickoff. If that cannot be guaranteed, Bridge clears/cancels the target and sends no model request. |
 
-Bridge optimizes for **high-fidelity, bounded-cost migration**:
+Installing Bridge adds **zero prompt tokens** to ordinary sessions. It is a host slash command, not a model tool or skill.
 
-- **Default — accuracy first:** the target restates the handoff in one short turn and waits. You verify it before any work starts.
-- **`--continue` — lower latency/cost:** the target restates and begins the next step in the **same model request**.
-- In both confirmation modes, any stored goal is paused before kickoff. The goal driver cannot silently queue another model round.
-- If pausing fails, Bridge fails closed: it clears the stored goal, cancels the target session, and sends no kickoff.
-- Installing the plugin adds **zero prompt tokens** to normal sessions. `/bridge` is a host slash command, not a model tool or skill.
-- Existing image analysis is copied verbatim outside the compressed summary. Only unresolved images may use vision tokens, and only when the target accepts images.
+## Evidence at a glance
 
-The release-acceptance run used one summary request per fixture. Confirm always reached first useful work in two target requests; `--continue` always did so in one. Token totals varied sharply with preset, output length, and cache state, so Bridge does not claim a universal percentage saving.
+The release gate is intentionally small and reproducible; these are regression results, not population guarantees.
 
-Observed across the fixed 12-cell release acceptance:
-
-| Token measure | Nominal | Processed |
-|---|---:|---:|
-| Confirm extra vs `--continue`, pooled summary + first useful work | **+12.82%** | +52.56% |
-| Confirm extra vs `--continue`, paired median | **+8.1%** | +65.6% |
-| Summary worker share of the clean acceptance suite | **20.74%** | 16.71% |
-
-Nominal is the primary comparison. Processed weights cache-read tokens equally and is not a bill; the worker row is a composition share, not causal overhead versus a no-Bridge baseline.
-
-<details>
-<summary><strong>Token definitions, ranges, and raw totals</strong></summary>
-
-`Nominal = uncached input + output`; `processed` also includes cache-read/cache-write tokens and is a sensitivity measure, not a bill. “Summary + first useful work” excludes the pre-existing source conversation and official compaction cost.
-
-Across the six paired fixtures, confirm's nominal extra had a median of +8.1% and a range of -47.9% to +206.7%; target-only nominal extra had a median of +11.0% and a range of -74.7% to +1059.1%. The wide spread is why request count is the stable product claim—not a fixed token-saving percentage.
-
-The six fixed summary workers used 19,551 nominal / 26,463 processed tokens. The 12 target sessions used 74,716 / 131,932. Counting each shared summary once, the clean acceptance components totalled 94,267 / 158,395 tokens. See the [full report](reports/v0.2.3-e2e-report.md) and [raw JSON](reports/v0.2.3-e2e-2026-08-20T13-19-13-924Z.raw.json).
-
-</details>
-
-In short: the safe default deliberately spends a separate confirmation turn; `--continue` combines confirmation and useful work into one target turn without enabling a background goal round.
-
-## Accuracy
-
-The default compression tier is `pro`. The latest rc.8 release acceptance covered 6 frozen fixtures and 12 target sessions:
-
-| Measure | Result |
+| Gate | Result |
 |---|---:|
-| Summary facts | **30/30** |
-| Target restatement facts | **60/60** |
-| First useful work facts | **60/60** |
-| Critical facts | **90/90** |
-| Obsolete-value resurrection | **0** |
-| Exact confirm / continue request count | **6/6 · 6/6** |
+| Five-part summary facts | **30/30** |
+| Target restatement / first useful work facts | **60/60 · 60/60** |
+| Critical facts / obsolete-value resurrection | **90/90 · 0** |
+| Existing image evidence / unresolved raw image | **5/5 · 5/5** |
+| Confirm / `--continue` target request shape | **2 · 1** to first useful work |
+| Confirm extra, paired nominal median | **+8.1%** vs `--continue` |
+| Summary worker share of clean acceptance components | **20.74% nominal** |
 
-This is a small, repair-driven release gate—not a statistical accuracy guarantee. It includes three 21-message sources with real compaction reuse plus three short sources, across minimal, standard, and code targets. Full methodology, raw token deltas, variability, and archive evidence are in the [v0.2.3 baseline + fix report](reports/v0.2.3-e2e-report.md).
-
-The separate rc.2 vision gate used non-guessable facts visible only in a PNG:
-
-| Vision path | Result | Raw images resent | Target model |
-|---|---:|---:|---|
-| Existing image analysis → verbatim evidence | **5/5** | 0 | vision-exp |
-| Unresolved image → installed `/bridge` command | **5/5** | 1 | vision-exp |
-
-The installed command's preview worker + first target response used 1,770 nominal / 4,714 processed tokens. That is one controlled fixture, not a universal overhead percentage. See the [rc.2 vision report](reports/v0.2.6-rc11-vision-report.md).
-
-<details>
-<summary><strong>Earlier compression-tier benchmark</strong></summary>
-
-The earlier August 2026 benchmark remains useful for comparing compression tiers:
-
-| Measure | Result |
-|---|---:|
-| Summary fidelity | 97.5% test / 96.7% validation |
-| Migrated fact usability | 87.5% test / 83.3% validation |
-| `pro` fact usability (8 runs) | **95%** |
-| `flash` fact usability (8 runs) | 80%, including one total-loss run |
-| Five-section schema compliance | 100% |
-
-`pro` and `flash` cost nearly the same here; the reason for defaulting to `pro` is lower failure variance, not a statistically proven mean advantage. Numbers and ports remain the main drift risk, which is why preview and restatement are part of the product path.
-
-See [the earlier benchmark, A/B control, and known weaknesses](docs/benchmark.md).
-
-</details>
+The token percentage varies widely with preset, response length, and cache state. The worker share is composition, not causal overhead versus no Bridge; the stable product claim is one additional confirmation request. Read the [design and evidence boundaries](docs/design.md), [full release report](reports/v0.2.3-e2e-report.md), and [vision report](reports/v0.2.6-rc11-vision-report.md).
 
 ## How it works
 
 ```text
-fold history → generate five-part summary → preview/edit → create target session
-             → pause stored goal → inject summary → restate (and optionally continue)
-image history → copy associated assistant text verbatim; unresolved raw images use the attachment gateway
+fold history -> five-part handoff -> preview/edit -> clean target session
+             -> pause stored goal -> inject -> restate -> wait or continue
+image history -> verbatim assistant evidence; unresolved originals use the attachment gateway
 ```
 
-The five sections are Goal, Current state, Key decisions & conventions, Key files, and Next step. Tool traces from the old preset are intentionally dropped: Bridge moves state, not incompatible tool history.
+The five sections are Goal, Current state, Key decisions and conventions, Key files, and Next step. The original session is never rewritten; archive the target and return to the source if the handoff is unsatisfactory.
 
-The original session is never rewritten. If the migration is unsatisfactory, return to it and archive the new session.
+## Migration decisions
 
-<details>
-<summary><strong>Images in rc.8+: raw transfer vs verbatim evidence</strong></summary>
+| Situation | Bridge behavior | Cost / fidelity effect |
+|---|---|---|
+| Plugin installed, no `/bridge` call | No prompt injection or model tool | **0 Bridge prompt tokens** |
+| `/bridge code` | One bounded summary worker; preview only | No target session is created |
+| Default `--go` | Target restates and waits | One explicit confirmation request before useful work |
+| `--go --continue` | Restate and work in one target request | Lower request count; no background goal round |
+| Image already has assistant analysis | Copy that response verbatim | No raw image is resent by default |
+| Image is unresolved and target accepts images | Copy the original attachment and preserve the source VLM | Vision pricing comes from the selected provider |
+| Image is unresolved and target is text-only | Prompt admission rejects the image; Bridge sends a visible text fallback | No hidden local VLM and no silent claim of visual understanding |
 
-Bridge uses an automatic, accuracy-first image policy:
+## Compatibility
 
-- An image-only user message never disappears from source material.
-- If the source turn has associated assistant text, Bridge appends that text **verbatim** under `Visual evidence`; the summary worker cannot rewrite it. The preview deliberately calls it an associated response—not proof that every pixel was understood.
-- If no assistant text follows the image, Bridge marks it `Unresolved`. On hosts with durable attachment recovery it reads the source attachment and tries to include the raw image in the target kickoff.
-- Before kickoff, Bridge copies the source provider, model, and reasoning effort to the blank target. This prevents the preview worker's model selection from silently replacing a vision route.
-- An image-capable target receives the raw image plus the handoff. A text-only DeepSeek target rejects the image during host admission, before a message or model request is created; Bridge then sends the text handoff with an explicit unresolved warning.
-- Raw images are not resent when verbatim evidence already exists, avoiding unnecessary visual-token and cache cost. Reattach the source image when the preserved response is insufficient for the next step.
+| DSH baseline | Text handoff | Raw unresolved image | Verification boundary |
+|---|---:|---:|---|
+| 0.1.0-rc.6 / rc.7 | Yes | Optional gateway unavailable | Narrow RPC contract and text compatibility tests |
+| 0.1.0-rc.8 | Yes | Host-dependent | Real install, restart, command lifecycle, and migration baseline |
+| 0.1.1-rc.2 | Yes | Yes | Official WebUI migration with `deepseek-v4-flash-vision-exp`, 13/13 doctor methods, and 5/5 vision gates |
 
-The normal five-part summary remains bounded by `summaryCharBudget` (2,400 characters by default). Verbatim visual evidence has a separate 60,000-character budget and is admitted as whole blocks: Bridge may omit an older block with a visible warning, but never cuts an image-derived response in the middle. Copying existing text adds no model round; a successfully attached raw image is priced by the selected vision provider.
+CI covers Node.js 22 and 24. Run `/bridge --doctor` after every Harness upgrade; it names missing required gateway methods instead of failing vaguely.
 
-rc.6/rc.7 remain compatible through the text path. Raw attachment recovery is an optional rc.8+ gateway capability and does not become a required `/bridge --doctor` method. The full raw-image path is live-tested on 0.1.1-rc.2 with `deepseek-v4-flash-vision-exp`.
+Current limits:
 
-On 0.1.1-rc.2, `session.selectModel` permits selecting a text-only model even when the session history contains images; `session.prompt` still enforces image capability and triggers Bridge's explicit text fallback. Bridge copies the source model before kickoff so a preview worker or host default cannot silently replace the source VLM.
+- installation needs one WebUI restart;
+- Bridge prints the created title and session ID because stable plugin-driven session navigation is not yet available;
+- preview normally takes 20–60 seconds and is bounded by `previewTimeoutMs`;
+- text-only models cannot inspect unresolved images;
+- each release-acceptance cell currently has one run, so the tables are release evidence rather than statistical guarantees.
 
-</details>
+The server command stays the compatibility core. A native migration card is technically possible through official client modules and slots, but is intentionally deferred until that prerelease contract is stable; see the [feasibility note](docs/native-webui-feasibility.md).
 
-<details>
-<summary><strong>Why not switch the preset in place?</strong></summary>
+## Documentation
 
-A preset is a system prompt, tool set, and plugin composition—not a tone setting. Tool calls already stored in the session are only valid under the composition that produced them. DeepSeek Harness therefore allows `agentPreset.select` only while a session is blank; changing it later would leave ghost tool calls that the new preset cannot execute.
-
-Bridge respects that boundary by opening a clean target session and carrying only a bounded handoff. Model and thinking-effort changes remain separate and can still happen inside a session.
-
-</details>
-
-<details>
-<summary><strong>Official preset factory, <code>@</code> session references, and TotoroPilot</strong></summary>
-
-- The official Agent Preset factory creates or configures presets for blank/future sessions. Bridge moves existing work into one of them.
-- rc.8's `@` reference attaches a bounded read-only snapshot of another session to the current session. Bridge creates a new session and removes old-preset tool traces.
-- **TotoroPilot** exposes the same migration pipeline through a GUI modal. The plugin itself remains usable directly in the official WebUI.
-
-</details>
-
-## Compatibility and limits
-
-Verified against DeepSeek Harness **0.1.0-rc.6, rc.7, rc.8, and 0.1.1-rc.2**, Node.js 22 and 24. Run `/bridge --doctor` after a Harness upgrade; it names missing gateway methods instead of failing vaguely.
-
-- The official WebUI currently needs one restart after install and cannot let a plugin navigate to the session it creates. Bridge prints the exact title and session ID.
-- DeepSeek text routes still cannot inspect images. Use an image-capable route such as `deepseek-v4-flash-vision-exp` for unresolved images; Bridge preserves that source selection on the target and fails visibly when no reusable attachment is available. It does not run a hidden local vision model.
-- On 0.1.1-rc.2, model selection itself no longer rejects this mismatch; prompt admission remains the enforcement point. Source-model copying is therefore a compatibility safeguard, not just a convenience.
-- Preview normally takes 20–60 seconds and is bounded by `previewTimeoutMs`.
-- Release acceptance now covers real compaction reuse, but only one run per cell; it should not be read as a population guarantee.
-- The older tier-comparison benchmark predates prompt+goal dual injection and remains labeled as historical evidence.
-
-For the full walkthrough, rollback checklist, configuration table, CLI path, and FAQ, read the [Chinese usage guide](docs/guide.zh.md).
-
-<details>
-<summary><strong>Advanced CLI and configuration</strong></summary>
-
-```bash
-dsh-bridge doctor
-dsh-bridge preview --to code --session <id>
-dsh-bridge migrate --to code --summary-file <path> --continue
-```
-
-Main settings: `modelTier`, `sourceCharBudget`, `summaryCharBudget`, `goalRounds`, `inject`, `lang`, `workerProvider`, `workerModel`, and `previewTimeoutMs`. Configure them in the profile's `cordis.patch.yml` or through the matching `DSH_BRIDGE_*` environment variables documented in the guide.
-
-The default injection mode is `both`: the summary is stored as a resumable goal and included in the kickoff prompt. The goal is paused before kickoff in both confirmation modes.
-
-</details>
+- [Design, safety, image policy, cost, and evidence](docs/design.md)
+- [Chinese install, configuration, rollback, and FAQ](docs/guide.zh.md)
+- [Release acceptance report](reports/v0.2.3-e2e-report.md)
+- [Vision migration report](reports/v0.2.6-rc11-vision-report.md)
+- [Historical compression benchmark](docs/benchmark.md)
 
 ## Development
 
 ```bash
-npm test          # build + typecheck + 125 tests
-npm run pack:check
+npm ci
+npm run verify
 ```
 
-CI verifies Node 22/24, generated `lib/`, datasets, package contents, and the narrow upstream RPC/command contract. Tests use a fake host and spend no model tokens. Evaluation is separate and uses your own local model credentials; see [docs/benchmark.md](docs/benchmark.md).
+`verify` builds and type-checks the project, runs 125 fake-host tests, checks generated `lib/` and datasets, then packs, installs, and imports the actual npm tarball. Tests spend no model tokens. `prepublishOnly` runs the same gate; GitHub releases also require the tag to match `package.json` before trusted npm publishing.
 
 Community listings: [Awesome DSH Plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) · [Awesome DeepSeek Harness](https://github.com/Dominic789654/awesome-deepseek-harness)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -13,31 +13,40 @@
 
 [English](README.md) | 中文
 
-通过可预览、固定 schema 的交接，把已有内容的 DeepSeek Harness 会话迁到另一套工具 preset；原会话始终不动。
+在 Web preset 做到一半，想换 Code preset 继续？直接切换会让旧工具组的调用历史留在新组合里。Bridge 先生成一份有界、可编辑的五段交接，再建立干净目标会话；原会话始终不动。
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/Totoro-qaq/dsh-plugin-bridge/main/assets/bridge-demo.zh.gif" width="880" alt="Bridge 在 DeepSeek Harness 官方 WebUI 中完成一次真实会话迁移">
 </p>
 
-[快速开始](#快速开始) · [安全与成本](#安全与成本) · [准确率](#准确率) · [工作原理](#工作原理) · [兼容性](#兼容性与局限)
+[快速开始](#快速开始) · [为什么是-bridge](#为什么是-bridge) · [实测证据](#实测证据) · [迁移决策](#迁移决策) · [兼容性](#兼容性)
 
 ## 快速开始
 
+从 npm 安装：
+
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.9
+dsh plugin --profile web add dsh-plugin-bridge
 # 重启一次 dsh web
+```
+
+GitHub 固定版本备用路径：
+
+```bash
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.10
 ```
 
 然后在官方 WebUI 输入：
 
 ```text
-/bridge                       列出可迁入的 preset
-/bridge code                  预览交接摘要，什么都不改
-/bridge code --go             迁移、复述，然后等你确认
-/bridge code --go --continue  在目标会话同一轮复述并开始工作
+/bridge                       列出目标 preset
+/bridge --doctor              DSH 升级后检查 host 契约
+/bridge code                  只预览交接，什么都不改
+/bridge code --go             迁移、复述，然后等待
+/bridge code --go --continue  在同一次目标请求里复述并开始工作
 ```
 
-预览可编辑。数字或路径不对时，修改输出里打印的摘要文件，再执行：
+预览可以编辑。数字或路径不对时，修改输出里打印的摘要文件，再执行：
 
 ```text
 /bridge code --go --file <路径>
@@ -45,173 +54,90 @@ dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.9
 
 卸载：`dsh plugin --profile web remove dsh-plugin-bridge`，然后重启 `dsh web`。
 
-> **最新实测——DSH 0.1.1-rc.2（2026-08-21）：**隔离安装、`/bridge` 注册、doctor 13/13、`standard → minimal` 预览与迁移、源 VLM 保持、未解析 PNG 原图搬运均通过；模型为 `deepseek-v4-flash-vision-exp`。rc.8 的完整生命周期与重启基线仍单独保留。
+## 为什么是 Bridge
 
-## 安全与成本
+| 承诺 | 具体含义 |
+|---|---|
+| **执行前预览** | `/bridge <preset>` 不创建目标、不改源会话；先检查或修改固定五段交接。 |
+| **迁状态，不迁工具痕迹** | 决策、路径、当前状态和下一步进入干净 preset；旧工具组的不兼容调用不会跟过去。 |
+| **失败时关闭迁移** | kickoff 前暂停目标；无法保证时清除/取消目标，不发送模型请求。 |
 
-Bridge 的目标是：**高准确率、成本有界的迁移**。
+只安装、不调用时，普通会话增加 **0 Bridge prompt token**。它是 host slash command，不是模型工具或 skill。
 
-- **默认模式——准确率优先：**目标会话用一个短轮次复述交接，然后等待；你确认无误后才开工。
-- **`--continue`——更低延迟/成本：**目标会话在**同一次模型请求**里完成复述并开始下一步。
-- 两种确认模式都会在 kickoff 前暂停已存储的 goal（如有），goal driver 不会静默追加模型轮次。
-- pause 失败时 fail closed：清除已存储的 goal、取消目标会话，不发送 kickoff。
-- 只安装、不迁移时，正常会话增加 **0 prompt token**。`/bridge` 是 host slash command，不是模型工具或 skill。
-- 已有识图结果会在压缩摘要之外逐字搬运；只有尚未解析且目标能接图时才可能产生视觉 token。
+## 实测证据
 
-release acceptance 中每个 fixture 只生成一次摘要。默认确认模式固定用 2 次目标请求抵达首次有效工作；`--continue` 固定用 1 次。实际 token 会随 preset、输出长度和缓存状态剧烈波动，所以本项目不宣称一个通用的固定节省百分比。
+这是小样本、可复现的回归门禁，不是总体准确率保证。
 
-修复后的 12-cell release acceptance 实测：
-
-| Token 指标 | Nominal | Processed |
-|---|---:|---:|
-| Confirm 相对 `--continue` 的额外成本，合并统计“摘要 + 首次有效工作” | **+12.82%** | +52.56% |
-| Confirm 相对 `--continue` 的额外成本，配对中位数 | **+8.1%** | +65.6% |
-| 摘要 worker 在干净验收组件中的占比 | **20.74%** | 16.71% |
-
-主口径是 nominal。Processed 把 cache-read 等权计入，不等于账单；worker 这一行是构成占比，不是相对“无 Bridge”基线的因果增量。
-
-<details>
-<summary><strong>Token 定义、离散范围与原始总量</strong></summary>
-
-`nominal = uncached input + output`；`processed` 还计入 cache-read/cache-write，是敏感性口径，不等于账单。“摘要 + 首次有效工作”不包含用户原会话的既有成本和官方 compaction 成本。
-
-6 对 fixture 中，confirm 的 nominal 额外成本中位数为 +8.1%，范围 -47.9%～+206.7%；只看目标会话时，中位数为 +11.0%，范围 -74.7%～+1059.1%。离散度很大，所以稳定的产品结论是“少一次请求”，不是固定节省某个 token 百分比。
-
-6 个修复后摘要 worker 共使用 19,551 nominal / 26,463 processed tokens；12 个目标会话共使用 74,716 / 131,932。每份共享摘要只计算一次时，干净验收组件合计 94,267 / 158,395 tokens。详见[完整报告](reports/v0.2.3-e2e-report.md)与[原始 JSON](reports/v0.2.3-e2e-2026-08-20T13-19-13-924Z.raw.json)。
-
-</details>
-
-一句话：安全默认值会明确多花一个“只复述”的确认轮；`--continue` 把确认和有效工作合并为一个目标轮，同时不开放后台 goal 轮次。
-
-## 准确率
-
-默认压缩档位为 `pro`。最新 rc.8 release acceptance 覆盖 6 份冻结 fixture 和 12 个目标会话：
-
-| 指标 | 结果 |
+| Gate | 结果 |
 |---|---:|
-| 摘要事实 | **30/30** |
-| 目标复述事实 | **60/60** |
-| 首次有效工作事实 | **60/60** |
-| 关键事实 | **90/90** |
-| 旧值复活 | **0** |
-| confirm / continue 请求数严格合规 | **6/6 · 6/6** |
+| 五段摘要事实 | **30/30** |
+| 目标复述 / 首次有效工作事实 | **60/60 · 60/60** |
+| 关键事实 / 旧值复活 | **90/90 · 0** |
+| 已有图片证据 / 未解析原图路径 | **5/5 · 5/5** |
+| Confirm / `--continue` 到首次有效工作的目标请求数 | **2 · 1** |
+| Confirm 相对 `--continue` 的 nominal 配对中位额外成本 | **+8.1%** |
+| 摘要 worker 在干净验收组件中的 nominal 占比 | **20.74%** |
 
-这是小样本、修复驱动的发布 gate，不是统计意义的准确率保证。它包含 3 个真实复用 compaction 的 21 消息源会话与 3 个短会话，目标覆盖 minimal、standard、code。完整方法、逐请求 token、离散度与归档证据见 [v0.2.3 基线 + 修复报告](reports/v0.2.3-e2e-report.md)。
-
-独立的 rc.2 视觉 gate 使用只存在于 PNG 内、不可猜的事实：
-
-| 视觉路径 | 结果 | 重发原图 | 目标模型 |
-|---|---:|---:|---|
-| 已有识图回答 → 逐字视觉证据 | **5/5** | 0 | vision-exp |
-| 未解析原图 → 安装版 `/bridge` 命令 | **5/5** | 1 | vision-exp |
-
-安装版命令的摘要 worker + 目标首次回答共使用 1,770 nominal / 4,714 processed tokens。这是单个受控 fixture 的绝对值，不是通用开销百分比。详见 [rc.2 视觉报告](reports/v0.2.6-rc11-vision-report.md)。
-
-<details>
-<summary><strong>更早的压缩档位 benchmark</strong></summary>
-
-更早的 2026 年 8 月 benchmark 仍用于比较压缩档位：
-
-| 指标 | 结果 |
-|---|---:|
-| 摘要保真 | 测试 97.5% / 验证 96.7% |
-| 迁移后事实可用性 | 测试 87.5% / 验证 83.3% |
-| `pro` 事实可用性（8 runs） | **95%** |
-| `flash` 事实可用性（8 runs） | 80%，含 1 次全灭 |
-| 五段 schema 合规 | 100% |
-
-`pro` 与 `flash` 在这里几乎同价；默认 `pro` 是因为失败方差更小，不是因为小样本已经证明均值显著更好。数字与端口仍是主要漂移风险，所以“预览 + 复述”属于产品主链路。
-
-更早实验的完整方法、A/B 对照与已知弱点见 [benchmark](docs/benchmark.md)。
-
-</details>
+token 百分比会随 preset、回复长度和缓存状态大幅波动；worker 占比是组成，不是相对“无 Bridge”的因果开销。稳定结论是默认确认多一个请求。边界和原始证据见[设计与证据说明](docs/design.md)、[完整 release report](reports/v0.2.3-e2e-report.md)和[视觉迁移报告](reports/v0.2.6-rc11-vision-report.md)。
 
 ## 工作原理
 
 ```text
-折叠历史 → 生成五段摘要 → 预览/编辑 → 创建目标会话
-         → 暂停存储目标 → 注入摘要 → 复述（可选同轮继续）
-图片历史 → 原样搬运关联助手正文；未解析原图走持久附件网关
+折叠历史 -> 五段交接 -> 预览/编辑 -> 干净目标会话
+         -> 暂停存储目标 -> 注入 -> 复述 -> 等待或同轮继续
+图片历史 -> 原样搬运助手证据；未解析原图走附件网关
 ```
 
-五段分别是：目标、当前状态、关键决策与约定、关键文件、下一步。旧 preset 的工具痕迹会被主动丢弃：迁的是状态，不是与新工具集不兼容的调用历史。
+五段分别是：目标、当前状态、关键决策与约定、关键文件、下一步。原会话不会被改写；接得不好时归档目标，直接回源会话。
 
-原会话不会被改写。迁移不满意时，点回原会话并归档新会话即可。
+## 迁移决策
 
-<details>
-<summary><strong>rc.8+ 图片：什么时候搬原图，什么时候搬原文</strong></summary>
+| 场景 | Bridge 行为 | 成本 / 保真影响 |
+|---|---|---|
+| 只安装，不调用 `/bridge` | 不注入提示，不注册模型工具 | **0 Bridge prompt token** |
+| `/bridge code` | 起一个有界摘要 worker，只输出预览 | 不创建目标会话 |
+| 默认 `--go` | 目标先复述再等待 | 首次有效工作前多一个显式确认请求 |
+| `--go --continue` | 同一次目标请求里复述并开工 | 请求数更低，没有后台 goal 轮次 |
+| 图片已有助手分析 | 逐字搬运对应回答 | 默认不重发原图 |
+| 图片未解析，目标可接图 | 搬原附件并保留源 VLM | 视觉费用由所选 provider 计算 |
+| 图片未解析，目标是纯文本模型 | prompt 准入拒图，Bridge 显式发送文字降级 | 不暗启本地 VLM，也不假装看懂图片 |
 
-Bridge 使用自动、准确率优先的图片策略：
+## 兼容性
 
-- 只有图片、没有文字的用户消息不再从取材中静默消失。
-- 图片同轮已有助手正文时，Bridge 将它逐字追加到 `视觉证据`，摘要 worker 无权改写。预览刻意称它为“关联助手响应”，而不是保证每个像素都已被理解。
-- 图片后没有助手正文时标记为 `未解析`。在支持持久附件恢复的 host 上，Bridge 读取源会话附件，并尝试把原图放进目标 kickoff。
-- kickoff 前，Bridge 会把源会话的 provider、model 与 reasoning effort 复制到空白目标，避免摘要 worker 的模型选择把视觉路由静默换掉。
-- 视觉目标会收到原图与交接；默认纯文本 DeepSeek 会在 host 准入阶段拒绝图片，此时消息与模型请求尚未创建，Bridge 再自动发送带未解析警告的纯文本交接。
-- 已有逐字证据时默认不重复发送原图，避免无必要的视觉 token 与缓存成本。如果原响应不足以支撑下一步，应从源会话重新附图核验。
+| DSH 基线 | 文本交接 | 未解析原图 | 验证边界 |
+|---|---:|---:|---|
+| 0.1.0-rc.6 / rc.7 | 支持 | 无可选附件网关 | 窄 RPC 契约与文本兼容测试 |
+| 0.1.0-rc.8 | 支持 | 取决于 host | 真实安装、重启、命令生命周期和迁移基线 |
+| 0.1.1-rc.2 | 支持 | 支持 | 官方 WebUI + `deepseek-v4-flash-vision-exp`，doctor 13/13，视觉 gate 5/5 |
 
-普通五段摘要仍受 `summaryCharBudget` 约束，默认 2,400 字符。逐字视觉证据使用独立的 60,000 字符预算，并以完整块为单位纳入：超限时会明确省略较早整块，但绝不会从一段图片结论中间截断。复制已有文字不增加模型轮次；原图成功进入视觉目标时，图片成本由所选视觉模型提供方计算。
+CI 覆盖 Node.js 22/24。每次升级 Harness 后先跑 `/bridge --doctor`；缺哪个必要网关方法会被直接点名。
 
-rc.6/rc.7 继续走文本兼容路径。原图读取只是 rc.8+ 的可选网关能力，不会被加入 `/bridge --doctor` 的必需方法集合；0.1.1-rc.2 + `deepseek-v4-flash-vision-exp` 的完整原图迁移已实测通过。
+当前边界：
 
-在 0.1.1-rc.2 上，即使会话历史含图，`session.selectModel` 也允许选中纯文本模型；`session.prompt` 仍会执行图片能力准入，并触发 Bridge 的显式文本降级。Bridge 会在 kickoff 前复制源模型，避免预览 worker 或 host 默认值把源 VLM 静默替换掉。
+- 安装后需要重启一次 WebUI；
+- 官方尚无稳定的插件跳转目标会话接口，Bridge 会打印新会话标题和 ID；
+- 预览通常 20–60 秒，并受 `previewTimeoutMs` 限制；
+- 纯文本模型无法读取未解析原图；
+- release acceptance 每个 cell 目前只有一次运行，表格是发布证据，不是统计保证。
 
-</details>
+服务端命令仍是兼容核心。官方 client module 与 slot 已证明原生迁移卡片可行，但其 prerelease 契约还不稳定，因此暂不把它塞进 v0.2.10；详见[可行性记录](docs/native-webui-feasibility.md)。
 
-<details>
-<summary><strong>为什么不在原会话直接切 preset？</strong></summary>
+## 文档
 
-preset 是系统提示、工具集和插件的完整组装，不是语气档位。历史里的工具调用只在生成它们的组装下合法。DeepSeek Harness 因此只允许空会话执行 `agentPreset.select`；中途切换会留下新 preset 无法执行的“幽灵调用”。
-
-Bridge 尊重这个边界：建立干净的目标会话，只携带一份有界交接。模型与思考强度仍是另一层，可以在会话内正常切换。
-
-</details>
-
-<details>
-<summary><strong>官方 preset 工厂、<code>@</code> 会话引用与 TotoroPilot</strong></summary>
-
-- 官方 Agent Preset 工厂用于给空白/未来会话创建和配置 preset；Bridge 用于把已有工作迁进其中一个 preset。
-- rc.8 的 `@` 引用把另一会话的有界只读快照加到当前会话；Bridge 新建会话，并去掉旧 preset 的工具痕迹。
-- **TotoroPilot** 用 GUI 弹窗承载同一迁移流水线；本插件本身可以直接在官方 WebUI 使用。
-
-</details>
-
-## 兼容性与局限
-
-已核对 DeepSeek Harness **0.1.0-rc.6、rc.7、rc.8 与 0.1.1-rc.2**，CI 覆盖 Node.js 22/24。升级 Harness 后可先运行 `/bridge --doctor`；缺少哪个网关方法会被直接点名。
-
-- 官方 WebUI 安装后目前需要重启一次，也不允许插件自动跳转到新建会话；Bridge 会打印准确标题与 session ID。
-- DeepSeek 文本路由仍不能读图。未解析图片应使用 `deepseek-v4-flash-vision-exp` 等视觉路由；Bridge 会把源模型选择保留到目标，并在附件不可复用时明确降级，不会暗中运行本地小视觉模型。
-- 在 0.1.1-rc.2 上，模型选择阶段不再拒绝这种不匹配，真正的能力闸留在 prompt 准入；因此复制源模型是兼容性护栏，不只是便利功能。
-- 预览通常需要 20–60 秒，受 `previewTimeoutMs` 上限保护。
-- release acceptance 已覆盖真实 compaction 复用，但每个 cell 仅 1 次，不应理解为总体保证值。
-- 更早的档位对比数据早于 prompt+goal 双注入，继续作为带边界的历史证据。
-
-完整操作、回退清单、配置表、CLI 路径与 FAQ 见 [中文使用指南](docs/guide.zh.md)。
-
-<details>
-<summary><strong>高级 CLI 与配置</strong></summary>
-
-```bash
-dsh-bridge doctor
-dsh-bridge preview --to code --session <id>
-dsh-bridge migrate --to code --summary-file <路径> --continue
-```
-
-主要配置：`modelTier`、`sourceCharBudget`、`summaryCharBudget`、`goalRounds`、`inject`、`lang`、`workerProvider`、`workerModel`、`previewTimeoutMs`。写入 profile 的 `cordis.patch.yml`，或使用指南中的 `DSH_BRIDGE_*` 环境变量。
-
-默认注入方式是 `both`：摘要既存为可恢复的 goal，也进入 kickoff prompt。两种确认模式都会先暂停 goal。
-
-</details>
+- [设计、安全、图片策略、成本与证据](docs/design.md)
+- [中文安装、配置、回退与 FAQ](docs/guide.zh.md)
+- [完整 release acceptance](reports/v0.2.3-e2e-report.md)
+- [视觉迁移报告](reports/v0.2.6-rc11-vision-report.md)
+- [历史压缩档位 benchmark](docs/benchmark.md)
 
 ## 开发验证
 
 ```bash
-npm test          # build + typecheck + 125 tests
-npm run pack:check
+npm ci
+npm run verify
 ```
 
-CI 检查 Node 22/24、生成的 `lib/`、数据集、安装包内容与上游 RPC/command 窄契约。测试使用 fake host，不消耗模型 token；评测另行运行并使用本机模型凭据，详见 [benchmark](docs/benchmark.md)。
+`verify` 会构建、类型检查、运行 125 项 fake-host 测试、核对 `lib/` 与数据集，再把真实 npm tarball 打包、安装并导入。测试不消耗模型 token。`prepublishOnly` 使用同一个 gate；GitHub Release 还会先检查 tag 与 `package.json` 版本一致，再走可信 npm 发布。
 
 社区收录：[Awesome DSH Plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) · [Awesome DeepSeek Harness](https://github.com/Dominic789654/awesome-deepseek-harness)
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,82 @@
+# Bridge design and evidence
+
+Bridge treats a preset as a complete tool-and-prompt assembly, not a style selector. A produced session therefore stays locked to the assembly that created its tool history. Migration opens a clean target session and carries a bounded state handoff instead of replaying incompatible calls.
+
+## Migration contract
+
+The handoff has five fixed sections:
+
+1. Goal
+2. Current state
+3. Key decisions and conventions
+4. Key files
+5. Next step
+
+The preview is a user-visible protocol step, not debug output. It is written to a file so numbers, paths, and decisions can be corrected before the target exists. Tool traces from the source preset are intentionally omitted.
+
+```text
+fold source history -> generate five-part handoff -> preview/edit
+                    -> create clean target -> pause stored goal
+                    -> inject handoff -> restate -> wait or continue
+```
+
+The source session is never rewritten. A failed or unsatisfactory target can be archived while the source remains available.
+
+## Safety boundary
+
+- Preview creates and archives a temporary summary worker, but does not mutate the source or create the target.
+- Migration creates a blank target under the selected preset.
+- A resumable goal may store the handoff, but Bridge pauses it before kickoff. Goal mutation alone does not inject model context, so the kickoff also contains the reviewed handoff.
+- If goal pause fails, Bridge attempts the optional `goal.clear`, cancels the target, and sends no kickoff.
+- `goalRounds` defaults to 1 as a second bound against an upstream autonomous goal loop.
+- Installing Bridge adds no model tool, skill, or persistent prompt text. Ordinary sessions therefore receive zero Bridge prompt tokens.
+
+## Confirmation and cost
+
+The default flow favors verification: the target restates the handoff in one short request and waits. `--continue` asks the same target request to restate and begin the next step.
+
+Across the fixed six-pair release acceptance, confirm used one more target request than `--continue`. Its nominal extra for summary plus first useful work had a paired median of **+8.1%** and a range of **-47.9% to +206.7%**. The summary worker represented **20.74%** of the clean acceptance components by nominal tokens. That share is composition, not causal overhead versus a no-Bridge baseline.
+
+`Nominal = uncached input + output`. The processed sensitivity measure also counts cache reads and writes equally; it is not a bill. Preset size, response length, and cache state caused wide variation, so Bridge claims a stable request-shape difference rather than a universal saving percentage.
+
+See the [release acceptance report](../reports/v0.2.3-e2e-report.md) and [raw JSON](../reports/v0.2.3-e2e-2026-08-20T13-19-13-924Z.raw.json).
+
+## Image evidence policy
+
+Image-derived information does not share the compressed-summary budget:
+
+- If an image already has an associated assistant response, Bridge copies that response verbatim under `Visual evidence`. The summary worker cannot rewrite it, and the raw image is not resent by default.
+- If no assistant response follows the image, Bridge marks it unresolved. On hosts with durable attachment recovery, it reads the original attachment and tries to include it in the target kickoff.
+- Before kickoff, Bridge copies the source provider, model, and reasoning effort to the blank target. This prevents the summary worker or host default from silently replacing a vision route.
+- A vision-capable target receives the raw image. A text-only target rejects it during prompt admission; Bridge then sends the text handoff with an explicit unresolved warning.
+
+The normal summary is capped by `summaryCharBudget` (2,400 characters by default). Verbatim visual evidence has a separate 60,000-character budget and is admitted as complete blocks; an older block may be omitted with a warning, but is never cut mid-statement.
+
+The rc.2 visual acceptance used facts visible only in a PNG. Existing visual evidence passed **5/5** without resending the image; the unresolved-image path passed **5/5** with one raw image sent to `deepseek-v4-flash-vision-exp`. See the [vision report](../reports/v0.2.6-rc11-vision-report.md).
+
+## Accuracy evidence
+
+The repair-driven release gate covered six frozen fixtures and twelve target sessions:
+
+| Measure | Result |
+|---|---:|
+| Summary facts | 30/30 |
+| Target restatement facts | 60/60 |
+| First useful work facts | 60/60 |
+| Critical facts | 90/90 |
+| Obsolete-value resurrection | 0 |
+| Exact confirm / continue request count | 6/6 / 6/6 |
+
+This is a regression gate, not a population-level accuracy guarantee. Three sources reused real compaction material and three were short sources; targets covered minimal, standard, and code presets. The earlier compression-tier study remains in [benchmark.md](benchmark.md) with its sampling and scoring limitations.
+
+## Why not switch in place?
+
+Stored tool calls are valid only under the preset composition that produced them. DeepSeek Harness therefore permits `agentPreset.select` only while a session is blank. Bypassing that lock would leave ghost calls that the new tool set cannot execute. Bridge keeps the lock and transfers state to a clean target.
+
+Model and reasoning-effort changes are separate from preset migration and may still happen within one session.
+
+## Upstream coupling
+
+Bridge deliberately uses a narrow host contract. `/bridge --doctor` checks thirteen required gateway methods and names missing methods after a Harness upgrade. Attachment recovery and `goal.clear` are optional enhancements and do not raise that baseline.
+
+The server-side slash command remains the compatibility core. A native WebUI card is feasible but would depend on prerelease client-module and slot contracts; the current decision is documented in [native-webui-feasibility.md](native-webui-feasibility.md).

--- a/docs/guide.zh.md
+++ b/docs/guide.zh.md
@@ -7,7 +7,13 @@
 前置：已安装 dsh（`dsh --version` 能输出版本，本插件已核对 0.1.0-rc.6 / rc.7 / rc.8，并在 0.1.1-rc.2 完成真实视觉迁移），并有一个可跑的 web profile（跑过一次 `dsh web` 即会自动初始化）。
 
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.9
+dsh plugin --profile web add dsh-plugin-bridge
+```
+
+需要固定 GitHub tag 或 npm 暂时不可用时：
+
+```bash
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.10
 ```
 
 发生了什么（不用手动干预）：
@@ -131,7 +137,7 @@ A：先打一次 `/bridge --doctor`，它会告诉你这套 host 暴露了十三
 A：图片已有助手分析时，Bridge 逐字搬这段视觉证据，不需要再次烧视觉 token。图片还没被分析时，源会话应选 `deepseek-v4-flash-vision-exp` 等视觉路由；Bridge 会在 kickoff 前把源 provider/model/reasoning effort 复制到目标，再搬原图。文本模型仍不能识图，Bridge 也不会暗中启动本地视觉模型。
 
 **Q：迁移后新会话「记得」多少？**
-A：26 组实验的探针可用性（事实可回忆率）：pro 档位 95%。丢的通常是「数字合理化」一类（端口被补全成常见值）——所以预览那一步请重点扫数字。
+A：当前 release gate 的 6 份摘要、12 个目标会话达到摘要 30/30、复述 60/60、首次有效工作 60/60，预定义旧值复活为 0。这是修复驱动的小样本回归门禁，不是总体准确率保证。更早 26 组档位实验里，pro 探针可用性为 95%；两组证据都提示数字与端口需要在预览里重点检查。
 
 **Q：为什么不在原会话直接切模式？**
 A：官方在网关层硬锁，且锁得对：历史里的工具调用只在原工具集下合法，换了组合会留下「幽灵调用」，不报错但质量静默劣化。Bridge 选择搬家而不是绕锁。

--- a/docs/native-webui-feasibility.md
+++ b/docs/native-webui-feasibility.md
@@ -1,0 +1,44 @@
+# Native WebUI migration card: feasibility note
+
+Status: **feasible, intentionally not shipped in v0.2.10**.
+
+## What was verified
+
+The official rc.8 WebUI supports third-party browser modules through a package-level `dsh.client` manifest. Its client runtime exposes a slot registry, and official plugins register occupants such as conversation views, input docks, settings items, and command renderers. This provides a real extension path; DOM patching or a forked WebUI is not required.
+
+The existing Bridge package is host-side only. It injects `commands` and `apiProxy`, and that slash-command path already works in the official WebUI. A client face could call the same host RPCs and render the same five-section preview without changing migration semantics.
+
+## Product shape
+
+A Bridge-native surface should express migration verification rather than copy a generic dashboard:
+
+1. choose a target preset;
+2. generate the five-section preview;
+3. show number, path, image, and truncation warnings beside the preview;
+4. require explicit confirmation;
+5. show the created title and session ID, with copy/open actions only when the host exposes stable navigation.
+
+The slash command remains available as the universal fallback.
+
+## Why it is not a P0 dependency
+
+- The client packages and slot contracts are still prerelease and version-coupled to the Harness WebUI.
+- Adding a browser face introduces React and multiple DSH client peer dependencies to a package that currently needs only the host contract.
+- A UI must not create a second migration implementation. The host-side preview, safety checks, and fail-closed behavior need to stay authoritative.
+- Current WebUI navigation does not provide Bridge with a stable, documented way to jump to the newly created session, so a card cannot yet promise seamless navigation.
+
+## Recommended implementation boundary
+
+When the client contract stabilizes, prefer either an optional client entry in this package or a thin `dsh-plugin-bridge-ui` companion. Both should consume Bridge RPC results and never reimplement history folding, summary creation, attachment policy, or goal safety in the browser.
+
+Prototype acceptance criteria:
+
+- loads and disposes through the official client-module lifecycle;
+- works on both wide and narrow official WebUI layouts;
+- exposes the exact same preview file and warnings as `/bridge`;
+- creates no target before confirmation;
+- proves cleanup after plugin removal and restart;
+- keeps `/bridge --doctor` and the host command usable when the client face fails;
+- pins and tests every supported DSH client-package version.
+
+Until those criteria can be maintained across releases, the official slash command is the more stable and lower-cost product surface.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-plugin-bridge",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-plugin-bridge",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"

--- a/package.json
+++ b/package.json
@@ -1,24 +1,33 @@
 {
   "name": "dsh-plugin-bridge",
-  "version": "0.2.9",
-  "description": "DeepSeek Harness Cordis bundle for cross-preset session migration via fixed-schema handoff summaries",
+  "version": "0.2.10",
+  "description": "Previewable cross-preset session migration for DeepSeek Harness with bounded, fixed-schema handoffs",
   "type": "module",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "files": [
     "lib",
     "docs",
+    "reports/v0.2.3-e2e-2026-08-20T13-19-13-924Z.raw.json",
+    "reports/v0.2.3-e2e-report.md",
+    "reports/v0.2.6-rc11-vision-report.md",
     "cordis.patch.yml",
     "README.md",
     "README.zh.md"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "build:check": "npm run build && git diff --exit-code -- lib",
     "typecheck": "tsc -p tsconfig.check.json",
     "prepack": "npm run build",
+    "prepublishOnly": "npm run verify",
     "test": "npm run build && npm run typecheck && node --experimental-strip-types --test test/*.test.mjs",
     "eval": "node eval/run.mjs",
-    "pack:check": "npm pack --dry-run"
+    "datasets:check": "node scripts/check-datasets.mjs",
+    "pack:check": "npm pack --dry-run",
+    "package:smoke": "node scripts/package-smoke.mjs",
+    "release:check": "node scripts/check-release-version.mjs",
+    "verify": "npm test && npm run build:check && npm run datasets:check && npm run package:smoke"
   },
   "keywords": [
     "dsh-plugin",

--- a/scripts/check-datasets.mjs
+++ b/scripts/check-datasets.mjs
@@ -1,0 +1,11 @@
+import { readFile } from 'node:fs/promises';
+
+for (const name of ['test', 'validation']) {
+  const file = new URL(`../datasets/${name}.json`, import.meta.url);
+  const data = JSON.parse(await readFile(file, 'utf8'));
+  if (!Array.isArray(data.themes) || data.themes.length === 0 || !data.templates?.plant) {
+    throw new Error(`${name} dataset is incomplete`);
+  }
+}
+
+console.log('datasets ok');

--- a/scripts/check-release-version.mjs
+++ b/scripts/check-release-version.mjs
@@ -1,0 +1,15 @@
+import { readFile } from 'node:fs/promises';
+
+const manifest = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'));
+const tag = process.argv[2] || process.env.GITHUB_REF_NAME;
+
+if (!tag) {
+  throw new Error('release tag is required (argument or GITHUB_REF_NAME)');
+}
+
+const expected = `v${manifest.version}`;
+if (tag !== expected) {
+  throw new Error(`release tag ${JSON.stringify(tag)} does not match package version ${JSON.stringify(expected)}`);
+}
+
+console.log(`release version ok: ${tag}`);

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -1,0 +1,56 @@
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const scratch = await mkdtemp(join(tmpdir(), 'dsh-bridge-package-'));
+
+function run(args, cwd = root) {
+  const result = spawnSync(npm, args, { cwd, encoding: 'utf8' });
+  if (result.status !== 0) {
+    throw new Error(`${npm} ${args.join(' ')} failed\n${result.stdout}\n${result.stderr}`);
+  }
+  return result.stdout;
+}
+
+try {
+  run(['run', 'build']);
+  // An outer `npm publish --dry-run` exports npm_config_dry_run to child npm
+  // processes. Override it here: this smoke must create and install a real
+  // temporary tarball even while the outer publication remains a dry run.
+  const raw = run(['pack', '--ignore-scripts', '--json', '--dry-run=false', '--pack-destination', scratch]);
+  const start = raw.indexOf('[');
+  if (start < 0) throw new Error(`npm pack did not return JSON:\n${raw}`);
+  const [packed] = JSON.parse(raw.slice(start));
+  if (!packed?.filename) throw new Error('npm pack returned no filename');
+
+  const tarball = join(scratch, packed.filename);
+  const installRoot = join(scratch, 'install');
+  await mkdir(installRoot);
+  run(['install', '--ignore-scripts', '--no-audit', '--no-fund', '--dry-run=false', '--prefix', installRoot, tarball], scratch);
+
+  const packageRoot = join(installRoot, 'node_modules', 'dsh-plugin-bridge');
+  const manifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'));
+  for (const relative of [
+    'lib/index.js',
+    'lib/index.d.ts',
+    'cordis.patch.yml',
+    'docs/design.md',
+    'reports/v0.2.3-e2e-report.md',
+  ]) {
+    if (!existsSync(join(packageRoot, relative))) throw new Error(`packed artifact is missing ${relative}`);
+  }
+
+  const plugin = await import(pathToFileURL(join(packageRoot, 'lib/index.js')).href);
+  if (plugin.name !== 'dsh-plugin-bridge' || typeof plugin.apply !== 'function') {
+    throw new Error('installed artifact does not expose the Bridge plugin entrypoint');
+  }
+
+  console.log(`package smoke ok: ${manifest.name}@${manifest.version} (${packed.entryCount} files)`);
+} finally {
+  await rm(scratch, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

- prepare `dsh-plugin-bridge@0.2.10` for its first npm release with one `npm run verify` gate, `prepublishOnly`, tag/version checks, and OIDC trusted publishing
- install and import the real packed tarball in CI; include the bounded evidence files in the package
- shorten both README homepages around the Bridge-specific flow: preview, move state rather than tool traces, and fail closed
- add a compact compatibility matrix, migration decision table, detailed design evidence, and an official WebUI client-extension feasibility note

## Verification

- `npm run verify` — 125/125 tests, generated `lib/` sync, datasets, tarball install/import
- `npm publish --dry-run --json` — 32-file package accepted
- README audit — English and Chinese pass
- isolated `@deepseek-ai/dsh@0.1.1-rc.2` profile — tarball installs, WebUI serves HTTP 200, installed `/bridge --doctor` reports 13/13
- tracked secret-pattern scan — clean

## Boundary

No migration runtime code changed. The existing rc.2 vision migration report remains the model-path acceptance evidence; this PR validates the new npm/install/release surface without spending another model run.