### PR TITLE
ci: pin npm trusted publishing runtime

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,9 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
           cache: npm
+      # Trusted publishing requires npm >=11.5.1. Pin the CLI instead of
+      # depending on whichever npm happens to ship with the runner's Node 24.
+      - run: npm install --global npm@11.19.0
       - run: npm ci
       - run: npm run release:check -- "${{ github.event.release.tag_name }}"
       - name: Publish to npm when this version is missing

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 </p>
 
 [![dsh-plugin](https://img.shields.io/badge/dsh-plugin-blue)](https://github.com/deepseek-ai/deepseek-harness)
+[![npm](https://img.shields.io/npm/v/dsh-plugin-bridge?color=cb3837)](https://www.npmjs.com/package/dsh-plugin-bridge)
 [![ci](https://github.com/Totoro-qaq/dsh-plugin-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/Totoro-qaq/dsh-plugin-bridge/actions/workflows/ci.yml)
 [![license](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![node ≥22](https://img.shields.io/badge/node-%E2%89%A522-339933)](package.json)

--- a/README.zh.md
+++ b/README.zh.md
@@ -5,6 +5,7 @@
 </p>
 
 [![dsh-plugin](https://img.shields.io/badge/dsh-plugin-blue)](https://github.com/deepseek-ai/deepseek-harness)
+[![npm](https://img.shields.io/npm/v/dsh-plugin-bridge?color=cb3837)](https://www.npmjs.com/package/dsh-plugin-bridge)
 [![ci](https://github.com/Totoro-qaq/dsh-plugin-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/Totoro-qaq/dsh-plugin-bridge/actions/workflows/ci.yml)
 [![license](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![node ≥22](https://img.shields.io/badge/node-%E2%89%A522-339933)](package.json)

--- a/scripts/package-smoke.mjs
+++ b/scripts/package-smoke.mjs
@@ -31,7 +31,21 @@ try {
   const tarball = join(scratch, packed.filename);
   const installRoot = join(scratch, 'install');
   await mkdir(installRoot);
-  run(['install', '--ignore-scripts', '--no-audit', '--no-fund', '--dry-run=false', '--prefix', installRoot, tarball], scratch);
+  // DSH supplies Cordis at runtime. Install that declared peer explicitly so
+  // npm 10/Node 22 does not spend an unbounded amount of time resolving the
+  // peer graph after this package already exists on the public registry.
+  run([
+    'install',
+    '--ignore-scripts',
+    '--legacy-peer-deps',
+    '--no-audit',
+    '--no-fund',
+    '--dry-run=false',
+    '--prefix',
+    installRoot,
+    tarball,
+    '@deepseek-ai/cordis@4.0.1',
+  ], scratch);
 
   const packageRoot = join(installRoot, 'node_modules', 'dsh-plugin-bridge');
   const manifest = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'));


### PR DESCRIPTION
## Summary

- pin npm 11.19 in the release workflow so OIDC trusted publishing does not depend on the runner-bundled CLI
- add the now-live npm version badge to both README homepages

## Verification

- npm trusted publisher lists `Totoro-qaq/dsh-plugin-bridge` + `publish.yml` with publish permission
- English and Chinese README audits pass
- `dsh-plugin-bridge@0.2.10` is live and was installed successfully from the registry in an isolated DSH 0.1.1-rc.2 profile