### PR TITLE
fix: avoid repeated global session scans

### DIFF
--- a/.github/tdd/issue-22-session-list-amplification.tdd.md
+++ b/.github/tdd/issue-22-session-list-amplification.tdd.md
@@ -23,8 +23,9 @@ The guarantees were derived from [GitHub issue #22](https://github.com/Totoro-qa
 |---|---|---|---|---|
 | 1 | Worker poll count no longer increases global `session.list` scans | `preview + execute：worker 轮询不应把 session.list 放大成全局扫描` | Integration | PASS |
 | 2 | A worker that starts after several polls is not mistaken for a completed worker | `waitIdle：会话排队慢也不会被误判成已跑完` | Integration | PASS |
-| 3 | Preview, migration, CLI, and slash-command paths accept and reuse one source-session row | Full `npm test` suite | Integration / CLI | PASS |
-| 4 | Generated package artifacts match TypeScript source and install/import successfully | `npm run build:check`, `npm run package:smoke` | Packaging | PASS |
+| 3 | Slash-command preview/confirm performs one source-list read per invocation | `/bridge code --go：用预览的摘要建目标会话，goal 只给一轮` | Command integration | PASS |
+| 4 | One-shot CLI run reuses the preview source row during migration | `run：预览 + 迁移一步到位` | CLI E2E | PASS |
+| 5 | Generated package artifacts match TypeScript source and install/import successfully | `npm run build:check`, `npm run package:smoke` | Packaging | PASS |
 
 ## Implementation boundary and known gap
 

--- a/.github/tdd/issue-22-session-list-amplification.tdd.md
+++ b/.github/tdd/issue-22-session-list-amplification.tdd.md
@@ -1,0 +1,33 @@
+# Issue #22: session list scan amplification
+
+## Source and user journeys
+
+The guarantees were derived from [GitHub issue #22](https://github.com/Totoro-qaq/dsh-plugin-bridge/issues/22), without a separate plan document.
+
+- As an operator with many sessions, I want Bridge to poll only the compression worker so migration latency and gateway CPU do not scale with every stored session.
+- As a Bridge user, I want a slowly queued worker to finish before its summary is read, so the optimization does not reintroduce the early-idle race.
+- As a CLI or WebUI user, I want one source-session snapshot reused throughout a command so preset, title, cwd, and placement do not trigger redundant global scans.
+
+## RED and GREEN evidence
+
+| Stage | Command | Result | Evidence |
+|---|---|---|---|
+| RED | `node --experimental-strip-types --test --test-name-pattern='preview \\+ execute' test/migrate.test.mjs` | Expected failure | 30 worker polls produced 32 `session.list` calls; assertion expected 1. Commit `7b48e0a`. |
+| GREEN | `node --experimental-strip-types --test --test-name-pattern='preview \\+ execute\|waitIdle' test/migrate.test.mjs` | PASS, 2/2 | Worker completion uses per-session `session.history`; the same 30-poll flow performs one source-list lookup, and delayed start remains correct. |
+| Full verification | `npm run verify` | PASS, 126/126 | Includes build, typecheck, generated `lib/` consistency, dataset checks, and isolated package smoke installation. |
+| Coverage | `node --experimental-strip-types --experimental-test-coverage --test test/migrate.test.mjs` | PASS | 89.43% line coverage overall; `src/migrate.ts` 94.43% line coverage. |
+
+## Test specification
+
+| # | What is guaranteed | Test | Type | Result |
+|---|---|---|---|---|
+| 1 | Worker poll count no longer increases global `session.list` scans | `preview + execute：worker 轮询不应把 session.list 放大成全局扫描` | Integration | PASS |
+| 2 | A worker that starts after several polls is not mistaken for a completed worker | `waitIdle：会话排队慢也不会被误判成已跑完` | Integration | PASS |
+| 3 | Preview, migration, CLI, and slash-command paths accept and reuse one source-session row | Full `npm test` suite | Integration / CLI | PASS |
+| 4 | Generated package artifacts match TypeScript source and install/import successfully | `npm run build:check`, `npm run package:smoke` | Packaging | PASS |
+
+## Implementation boundary and known gap
+
+DSH `0.1.1-rc.2` has no unary `session.get` or `session.status` RPC. Bridge therefore records the worker's pre-prompt event watermark and polls that session's bounded history tail for a newer `turn/end`. If upstream later exposes a direct completion/status method, it can replace this compatibility path without changing the migration contract.
+
+No real model tokens were used by these tests; runtime compatibility still relies on the already-supported upstream `turn/start` and `turn/end` history events.

--- a/.github/tdd/issue-22-session-list-amplification.tdd.md
+++ b/.github/tdd/issue-22-session-list-amplification.tdd.md
@@ -12,8 +12,8 @@ The guarantees were derived from [GitHub issue #22](https://github.com/Totoro-qa
 
 | Stage | Command | Result | Evidence |
 |---|---|---|---|
-| RED | `node --experimental-strip-types --test --test-name-pattern='preview \\+ execute' test/migrate.test.mjs` | Expected failure | 30 worker polls produced 32 `session.list` calls; assertion expected 1. Commit `7b48e0a`. |
-| GREEN | `node --experimental-strip-types --test --test-name-pattern='preview \\+ execute\|waitIdle' test/migrate.test.mjs` | PASS, 2/2 | Worker completion uses per-session `session.history`; the same 30-poll flow performs one source-list lookup, and delayed start remains correct. |
+| RED | `node --experimental-strip-types --test --test-name-pattern='preview \+ execute' test/migrate.test.mjs` | Expected failure | 30 worker polls produced 32 `session.list` calls; assertion expected 1. Commit `7b48e0a`. |
+| GREEN | `node --experimental-strip-types --test --test-name-pattern='preview \+ execute|waitIdle' test/migrate.test.mjs` | PASS, 2/2 | Worker completion uses per-session `session.history`; the same 30-poll flow performs one source-list lookup, and delayed start remains correct. |
 | Full verification | `npm run verify` | PASS, 126/126 | Includes build, typecheck, generated `lib/` consistency, dataset checks, and isolated package smoke installation. |
 | Coverage | `node --experimental-strip-types --experimental-test-coverage --test test/migrate.test.mjs` | PASS | 89.43% line coverage overall; `src/migrate.ts` 94.43% line coverage. |
 

--- a/.github/tdd/issue-22-session-list-amplification.tdd.md
+++ b/.github/tdd/issue-22-session-list-amplification.tdd.md
@@ -31,4 +31,22 @@ The guarantees were derived from [GitHub issue #22](https://github.com/Totoro-qa
 
 DSH `0.1.1-rc.2` has no unary `session.get` or `session.status` RPC. Bridge therefore records the worker's pre-prompt event watermark and polls that session's bounded history tail for a newer `turn/end`. If upstream later exposes a direct completion/status method, it can replace this compatibility path without changing the migration contract.
 
-No real model tokens were used by these tests; runtime compatibility still relies on the already-supported upstream `turn/start` and `turn/end` history events.
+## Live model acceptance
+
+On 2026-08-24, the current branch was packed and installed into a fresh isolated official `@deepseek-ai/dsh@0.1.1-rc.2` Web profile. One real `deepseek-official/deepseek-v4-flash` migration ran through the installed command registry:
+
+| Gate | Result |
+|---|---:|
+| `/bridge --doctor` | 13/13 |
+| Source response exact low-collision facts | 4/4 |
+| `/bridge minimal --tier flash --lang en` preview facts | 4/4 |
+| Migrated minimal target first response facts | 4/4 |
+| Preview duration | 5,319 ms |
+| Preview worker nominal tokens | 1,998 |
+| Target nominal tokens | 1,804 |
+| Migration total nominal tokens | 3,802 |
+| Test sessions archived | 3/3 |
+
+The separate source-fixture turn used 9,188 nominal tokens and is excluded from migration overhead. The target preserved the source model and `high` reasoning effort. The source, preview worker, and target were all cancelled if needed and archived after the assertions.
+
+The automated suite itself uses no model tokens. The live check is one controlled compatibility run, not a latency or token population benchmark; runtime compatibility still relies on upstream `turn/start` and `turn/end` history events.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -279,6 +279,7 @@ async function main(argv) {
             const source = await findSession(rpc, sessionId).catch(() => undefined);
             const result = await executeMigration(rpc, {
                 sessionId,
+                sourceSession: source,
                 to,
                 summary,
                 goalRounds: num(args, 'goal-rounds'),
@@ -322,9 +323,9 @@ async function main(argv) {
                 ...(num(args, 'worker-timeout') === undefined ? {} : { workerTimeoutMs: num(args, 'worker-timeout') }),
                 onProgress: progress,
             });
-            const source = await findSession(rpc, sessionId).catch(() => undefined);
             const result = await executeMigration(rpc, {
                 sessionId,
+                sourceSession: preview.sourceSession,
                 to,
                 summary: preview.summary,
                 lang: preview.lang,
@@ -332,7 +333,7 @@ async function main(argv) {
                 inject: injectOf(args),
                 kickoff: !bool(args, 'no-kickoff'),
                 autoContinue: bool(args, 'continue'),
-                title: str(args, 'title') ?? migratedTitle(titleOf(source), to),
+                title: str(args, 'title') ?? migratedTitle(titleOf(preview.sourceSession), to),
                 onProgress: progress,
             });
             out({ ...result, summary: preview.summary, source: preview.source }, () => `已迁移到 ${result.agentPreset}：${result.sessionId}\n\n${preview.summary}\n`);

--- a/lib/command.js
+++ b/lib/command.js
@@ -171,10 +171,12 @@ export function createBridgeCommand(deps) {
             const rpc = deps.rpcFor(invocation.signal);
             const config = deps.config;
             let presets;
+            let sourceSession;
             let current;
             try {
                 presets = await listPresets(rpc);
-                current = (await findSession(rpc, sessionId))?.agentPreset;
+                sourceSession = await findSession(rpc, sessionId);
+                current = sourceSession?.agentPreset;
             }
             catch (error) {
                 return { kind: 'error', text: describe(error) };
@@ -258,11 +260,11 @@ export function createBridgeCommand(deps) {
                     };
                 }
                 try {
-                    const row = await findSession(rpc, sessionId).catch(() => undefined);
-                    const sourceTitle = titleOf(row);
+                    const sourceTitle = titleOf(sourceSession);
                     const targetTitle = sourceTitle ? migratedTitle(sourceTitle, target) : (runLang === 'en' ? `Migrated to ${target}` : migratedTitle(sourceTitle, target));
                     const result = await executeMigration(rpc, {
                         sessionId,
+                        sourceSession,
                         to: target,
                         summary,
                         goalRounds: parsed.goalRounds ?? config.goalRounds,
@@ -311,6 +313,7 @@ export function createBridgeCommand(deps) {
             try {
                 const preview = await previewMigration(rpc, {
                     sessionId,
+                    sourceSession,
                     tier: parsed.tier ?? config.modelTier,
                     sourceCharBudget: config.sourceCharBudget,
                     summaryCharBudget: config.summaryCharBudget,

--- a/lib/migrate.d.ts
+++ b/lib/migrate.d.ts
@@ -69,16 +69,18 @@ export declare function resolveWorkerModel(rpc: Rpc, sessionId: string, tier: Mo
 export declare function resolveWorkerPreset(rpc: Rpc): Promise<string | undefined>;
 export interface WaitOptions {
     timeoutMs?: number;
-    /** 等「开始跑」的宽限期；超过还没 running 就当它已经跑完了。 */
+    /** 等待新 `turn/start` 的宽限期；超过仍未出现就按未启动处理。 */
     startGraceMs?: number;
     pollMs?: number;
+    /** 只观察这个事件序号之后的新一轮；worker 新建后通常为 0。 */
+    afterSeq?: number;
 }
 /**
- * 等一个会话回到空闲。
+ * 等一个会话的新一轮写入 `turn/end`。
  *
- * 旧实现是「先 sleep 2s，再看 running 是不是 false」——host 排队稍慢一点，
- * 第一次轮询就会把「还没开始」误判成「已经跑完」，取到的是上一轮的回答。
- * 这里先等它真的 running 起来（有宽限期），再等它落回 false。
+ * `session.list` 是全局列表，拿它每两秒轮询一个 worker 会把会话总量放大成
+ * O(会话数 × 轮询次数)。`session.history` 则只读目标会话；用 prompt 前的事件
+ * 水位隔开旧轮次后，`turn/start` / `turn/end` 也比易过期的 running 快照更可靠。
  */
 export declare function waitIdle(rpc: Rpc, sessionId: string, options?: WaitOptions): Promise<{
     idle: boolean;
@@ -93,6 +95,8 @@ export declare function foldedHistory(rpc: Rpc, sessionId: string, options?: {
 export declare function lastAssistantText(rpc: Rpc, sessionId: string): Promise<string>;
 export interface PreviewOptions {
     sessionId: string;
+    /** 同一命令已经读取过的源会话行，避免重复扫描全局列表。 */
+    sourceSession?: SessionRow;
     tier?: ModelTier;
     provider?: string;
     model?: string;
@@ -125,6 +129,8 @@ export interface PreviewResult {
 export declare function previewMigration(rpc: Rpc, options: PreviewOptions): Promise<PreviewResult>;
 export interface MigrateOptions {
     sessionId: string;
+    /** 同一流程已经读取过的源会话行，避免重复扫描全局列表。 */
+    sourceSession?: SessionRow;
     to: string;
     summary: string;
     lang?: 'zh' | 'en';

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -95,30 +95,39 @@ export async function resolveWorkerPreset(rpc) {
     return presets.find((preset) => preset.isDefault)?.id;
 }
 /**
- * 等一个会话回到空闲。
+ * 等一个会话的新一轮写入 `turn/end`。
  *
- * 旧实现是「先 sleep 2s，再看 running 是不是 false」——host 排队稍慢一点，
- * 第一次轮询就会把「还没开始」误判成「已经跑完」，取到的是上一轮的回答。
- * 这里先等它真的 running 起来（有宽限期），再等它落回 false。
+ * `session.list` 是全局列表，拿它每两秒轮询一个 worker 会把会话总量放大成
+ * O(会话数 × 轮询次数)。`session.history` 则只读目标会话；用 prompt 前的事件
+ * 水位隔开旧轮次后，`turn/start` / `turn/end` 也比易过期的 running 快照更可靠。
  */
 export async function waitIdle(rpc, sessionId, options = {}) {
     const pollMs = options.pollMs ?? 2000;
     const deadline = Date.now() + (options.timeoutMs ?? 360_000);
     const startBy = Date.now() + (options.startGraceMs ?? 25_000);
+    const afterSeq = options.afterSeq ?? 0;
     let started = false;
     while (Date.now() < deadline) {
         await sleep(pollMs);
-        const row = await findSession(rpc, sessionId).catch(() => undefined);
-        if (row?.running) {
+        const events = await tailSessionEvents(rpc, sessionId).catch(() => []);
+        const fresh = events.filter((event) => typeof event.seq === 'number' && event.seq > afterSeq);
+        if (fresh.some((event) => event.type === 'turn/start'))
             started = true;
-            continue;
-        }
-        if (started)
+        if (fresh.some((event) => event.type === 'turn/end'))
             return { idle: true, started: true };
-        if (Date.now() > startBy)
+        if (!started && Date.now() > startBy)
             return { idle: true, started: false };
     }
     return { idle: false, started };
+}
+/** 读取单个会话的尾页；不触发全局 session.list 扫描。 */
+async function tailSessionEvents(rpc, sessionId) {
+    const res = await rpc('session.history', { sessionId, maxMessages: 2 }, 60_000);
+    return (res.events ?? []).map((entry) => entry.event);
+}
+async function latestSessionSeq(rpc, sessionId) {
+    const events = await tailSessionEvents(rpc, sessionId);
+    return events.reduce((max, event) => (typeof event.seq === 'number' && event.seq > max ? event.seq : max), 0);
 }
 /** 拉取并折叠会话历史（按需翻页）。 */
 export async function foldedHistory(rpc, sessionId, options = {}) {
@@ -149,7 +158,7 @@ export async function lastAssistantText(rpc, sessionId) {
 /** 生成交接摘要：取材 → 起临时工人 → 收摘要 → 归档工人。 */
 export async function previewMigration(rpc, options) {
     const progress = options.onProgress ?? (() => { });
-    const sourceSession = await findSession(rpc, options.sessionId);
+    const sourceSession = options.sourceSession ?? await findSession(rpc, options.sessionId);
     progress('拉取并折叠会话历史…');
     const messages = await foldedHistory(rpc, options.sessionId);
     const source = buildBridgeSource(messages, { sourceCharBudget: options.sourceCharBudget });
@@ -179,6 +188,7 @@ export async function previewMigration(rpc, options) {
             });
         }
         const instruction = buildBridgeInstruction(lang, { summaryCharBudget: options.summaryCharBudget });
+        const workerBaselineSeq = await latestSessionSeq(rpc, worker.sessionId).catch(() => 0);
         await rpc('session.prompt', {
             sessionId: worker.sessionId,
             mode: 'queue',
@@ -187,6 +197,7 @@ export async function previewMigration(rpc, options) {
         progress('等待摘要…');
         const settled = await waitIdle(rpc, worker.sessionId, {
             timeoutMs: options.workerTimeoutMs ?? 360_000,
+            afterSeq: workerBaselineSeq,
             ...(options.pollMs === undefined ? {} : { pollMs: options.pollMs, startGraceMs: options.pollMs * 6 }),
         });
         if (!settled.idle) {
@@ -280,7 +291,7 @@ export async function executeMigration(rpc, options) {
     const summary = options.summary.trim();
     if (!summary)
         throw new RpcError('bridge.migrate', 'empty-summary', '摘要为空，拒绝迁移。');
-    const sourceSession = await findSession(rpc, options.sessionId);
+    const sourceSession = options.sourceSession ?? await findSession(rpc, options.sessionId);
     const where = await placement(rpc, sourceSession, options.sessionId);
     let sourceModel;
     try {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -305,6 +305,7 @@ async function main(argv: string[]): Promise<number> {
       const source = await findSession(rpc, sessionId).catch(() => undefined);
       const result = await executeMigration(rpc, {
         sessionId,
+        sourceSession: source,
         to,
         summary,
         goalRounds: num(args, 'goal-rounds'),
@@ -346,9 +347,9 @@ async function main(argv: string[]): Promise<number> {
         ...(num(args, 'worker-timeout') === undefined ? {} : { workerTimeoutMs: num(args, 'worker-timeout') }),
         onProgress: progress,
       });
-      const source = await findSession(rpc, sessionId).catch(() => undefined);
       const result = await executeMigration(rpc, {
         sessionId,
+        sourceSession: preview.sourceSession,
         to,
         summary: preview.summary,
         lang: preview.lang,
@@ -356,7 +357,7 @@ async function main(argv: string[]): Promise<number> {
         inject: injectOf(args),
         kickoff: !bool(args, 'no-kickoff'),
         autoContinue: bool(args, 'continue'),
-        title: str(args, 'title') ?? migratedTitle(titleOf(source), to),
+        title: str(args, 'title') ?? migratedTitle(titleOf(preview.sourceSession), to),
         onProgress: progress,
       });
       out({ ...result, summary: preview.summary, source: preview.source }, () =>

--- a/src/command.ts
+++ b/src/command.ts
@@ -24,6 +24,7 @@ import {
   type Lang,
   type ModelTier,
   type PresetRow,
+  type SessionRow,
 } from './migrate.ts';
 import type { MethodProbe } from './api-rpc.ts';
 import { RpcError, type Rpc } from './rpc.ts';
@@ -248,10 +249,12 @@ export function createBridgeCommand(deps: BridgeCommandDeps): {
       const config = deps.config;
 
       let presets: PresetRow[];
+      let sourceSession: SessionRow | undefined;
       let current: string | undefined;
       try {
         presets = await listPresets(rpc);
-        current = (await findSession(rpc, sessionId))?.agentPreset;
+        sourceSession = await findSession(rpc, sessionId);
+        current = sourceSession?.agentPreset;
       } catch (error) {
         return { kind: 'error', text: describe(error) };
       }
@@ -334,11 +337,11 @@ export function createBridgeCommand(deps: BridgeCommandDeps): {
           };
         }
         try {
-          const row = await findSession(rpc, sessionId).catch(() => undefined);
-          const sourceTitle = titleOf(row);
+          const sourceTitle = titleOf(sourceSession);
           const targetTitle = sourceTitle ? migratedTitle(sourceTitle, target) : (runLang === 'en' ? `Migrated to ${target}` : migratedTitle(sourceTitle, target));
           const result = await executeMigration(rpc, {
             sessionId,
+            sourceSession,
             to: target,
             summary,
             goalRounds: parsed.goalRounds ?? config.goalRounds,
@@ -386,6 +389,7 @@ export function createBridgeCommand(deps: BridgeCommandDeps): {
       try {
         const preview = await previewMigration(rpc, {
           sessionId,
+          sourceSession,
           tier: parsed.tier ?? config.modelTier,
           sourceCharBudget: config.sourceCharBudget,
           summaryCharBudget: config.summaryCharBudget,

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -156,17 +156,19 @@ export async function resolveWorkerPreset(rpc: Rpc): Promise<string | undefined>
 
 export interface WaitOptions {
   timeoutMs?: number;
-  /** 等「开始跑」的宽限期；超过还没 running 就当它已经跑完了。 */
+  /** 等待新 `turn/start` 的宽限期；超过仍未出现就按未启动处理。 */
   startGraceMs?: number;
   pollMs?: number;
+  /** 只观察这个事件序号之后的新一轮；worker 新建后通常为 0。 */
+  afterSeq?: number;
 }
 
 /**
- * 等一个会话回到空闲。
+ * 等一个会话的新一轮写入 `turn/end`。
  *
- * 旧实现是「先 sleep 2s，再看 running 是不是 false」——host 排队稍慢一点，
- * 第一次轮询就会把「还没开始」误判成「已经跑完」，取到的是上一轮的回答。
- * 这里先等它真的 running 起来（有宽限期），再等它落回 false。
+ * `session.list` 是全局列表，拿它每两秒轮询一个 worker 会把会话总量放大成
+ * O(会话数 × 轮询次数)。`session.history` 则只读目标会话；用 prompt 前的事件
+ * 水位隔开旧轮次后，`turn/start` / `turn/end` 也比易过期的 running 快照更可靠。
  */
 export async function waitIdle(
   rpc: Rpc,
@@ -176,18 +178,34 @@ export async function waitIdle(
   const pollMs = options.pollMs ?? 2000;
   const deadline = Date.now() + (options.timeoutMs ?? 360_000);
   const startBy = Date.now() + (options.startGraceMs ?? 25_000);
+  const afterSeq = options.afterSeq ?? 0;
   let started = false;
   while (Date.now() < deadline) {
     await sleep(pollMs);
-    const row = await findSession(rpc, sessionId).catch(() => undefined);
-    if (row?.running) {
-      started = true;
-      continue;
-    }
-    if (started) return { idle: true, started: true };
-    if (Date.now() > startBy) return { idle: true, started: false };
+    const events = await tailSessionEvents(rpc, sessionId).catch(() => [] as SessionEvent[]);
+    const fresh = events.filter((event) => typeof event.seq === 'number' && event.seq > afterSeq);
+    if (fresh.some((event) => event.type === 'turn/start')) started = true;
+    if (fresh.some((event) => event.type === 'turn/end')) return { idle: true, started: true };
+    if (!started && Date.now() > startBy) return { idle: true, started: false };
   }
   return { idle: false, started };
+}
+
+/** 读取单个会话的尾页；不触发全局 session.list 扫描。 */
+async function tailSessionEvents(rpc: Rpc, sessionId: string): Promise<SessionEvent[]> {
+  const res = await rpc<{ events?: { event: SessionEvent }[] }>(
+    'session.history',
+    { sessionId, maxMessages: 2 },
+    60_000,
+  );
+  return (res.events ?? []).map((entry) => entry.event);
+}
+
+async function latestSessionSeq(rpc: Rpc, sessionId: string): Promise<number> {
+  const events = await tailSessionEvents(rpc, sessionId);
+  return events.reduce((max, event) => (
+    typeof event.seq === 'number' && event.seq > max ? event.seq : max
+  ), 0);
 }
 
 /** 拉取并折叠会话历史（按需翻页）。 */
@@ -227,6 +245,8 @@ export async function lastAssistantText(rpc: Rpc, sessionId: string): Promise<st
 
 export interface PreviewOptions {
   sessionId: string;
+  /** 同一命令已经读取过的源会话行，避免重复扫描全局列表。 */
+  sourceSession?: SessionRow;
   tier?: ModelTier;
   provider?: string;
   model?: string;
@@ -254,7 +274,7 @@ export interface PreviewResult {
 /** 生成交接摘要：取材 → 起临时工人 → 收摘要 → 归档工人。 */
 export async function previewMigration(rpc: Rpc, options: PreviewOptions): Promise<PreviewResult> {
   const progress = options.onProgress ?? (() => {});
-  const sourceSession = await findSession(rpc, options.sessionId);
+  const sourceSession = options.sourceSession ?? await findSession(rpc, options.sessionId);
 
   progress('拉取并折叠会话历史…');
   const messages = await foldedHistory(rpc, options.sessionId);
@@ -288,6 +308,7 @@ export async function previewMigration(rpc: Rpc, options: PreviewOptions): Promi
         });
     }
     const instruction = buildBridgeInstruction(lang, { summaryCharBudget: options.summaryCharBudget });
+    const workerBaselineSeq = await latestSessionSeq(rpc, worker.sessionId).catch(() => 0);
     await rpc('session.prompt', {
       sessionId: worker.sessionId,
       mode: 'queue',
@@ -296,6 +317,7 @@ export async function previewMigration(rpc: Rpc, options: PreviewOptions): Promi
     progress('等待摘要…');
     const settled = await waitIdle(rpc, worker.sessionId, {
       timeoutMs: options.workerTimeoutMs ?? 360_000,
+      afterSeq: workerBaselineSeq,
       ...(options.pollMs === undefined ? {} : { pollMs: options.pollMs, startGraceMs: options.pollMs * 6 }),
     });
     if (!settled.idle) {
@@ -326,6 +348,8 @@ export async function previewMigration(rpc: Rpc, options: PreviewOptions): Promi
 
 export interface MigrateOptions {
   sessionId: string;
+  /** 同一流程已经读取过的源会话行，避免重复扫描全局列表。 */
+  sourceSession?: SessionRow;
   to: string;
   summary: string;
   lang?: 'zh' | 'en';
@@ -436,7 +460,7 @@ export async function executeMigration(rpc: Rpc, options: MigrateOptions): Promi
   const summary = options.summary.trim();
   if (!summary) throw new RpcError('bridge.migrate', 'empty-summary', '摘要为空，拒绝迁移。');
 
-  const sourceSession = await findSession(rpc, options.sessionId);
+  const sourceSession = options.sourceSession ?? await findSession(rpc, options.sessionId);
   const where = await placement(rpc, sourceSession, options.sessionId);
   let sourceModel: ModelSelection | undefined;
   try {

--- a/test/cli.test.mjs
+++ b/test/cli.test.mjs
@@ -136,6 +136,11 @@ test('run：预览 + 迁移一步到位', async (t) => {
     { DSH_API: api, DSH_SESSION_ID: host.sourceSessionId });
   assert.equal(res.code, 0, res.stderr);
   assert.equal(JSON.parse(res.stdout).agentPreset, 'standard');
+  assert.equal(
+    host.state.calls.filter((call) => call.method === 'session.list').length,
+    1,
+    'run 应在 preview 与 migrate 之间复用源会话快照',
+  );
 });
 
 test('拿不到会话 id 时给出可执行的提示，退出码 2', async (t) => {

--- a/test/command.test.mjs
+++ b/test/command.test.mjs
@@ -123,6 +123,11 @@ test('/bridge code --go：用预览的摘要建目标会话，goal 只给一轮'
   assert.equal(host.state.goals[0].maxGoalRounds, 1);
   assert.equal(host.state.pausedGoals.length, 1);
   assert.ok(host.state.goals[0].objective.includes('7101'));
+  assert.equal(
+    host.state.calls.filter((call) => call.method === 'session.list').length,
+    2,
+    '预览和确认是两次命令调用，每次只应读取一次源会话列表',
+  );
 });
 
 test('/bridge code --go --continue：同一轮继续，goal 仍暂停', async () => {

--- a/test/fake-host.mjs
+++ b/test/fake-host.mjs
@@ -55,7 +55,7 @@ export function createFakeHost(options = {}) {
     const sessionId = `s-${(nextId += 1)}`;
     sessions.set(sessionId, {
       sessionId, agentPreset, running: false, blank: true, events: [],
-      pendingPolls: 0, startPolls: 0, reply: null, ...extra,
+      pendingPolls: 0, startPolls: 0, turnStarted: false, reply: null, ...extra,
     });
     return sessions.get(sessionId);
   };
@@ -82,14 +82,19 @@ export function createFakeHost(options = {}) {
         continue;
       }
       if (session.pendingPolls > 0) {
-        session.pendingPolls -= 1;
+        if (!session.turnStarted) {
+          session.turnStarted = true;
+          push(session, 'turn/start', {});
+        }
         session.running = true;
+        session.pendingPolls -= 1;
         if (session.pendingPolls === 0) {
           session.running = false;
           if (session.reply) {
             push(session, 'assistant/message', { turn: 9, step: 1, message: { content: [{ type: 'text', text: session.reply }] } });
             session.reply = null;
           }
+          push(session, 'turn/end', {});
         }
       }
     }
@@ -151,6 +156,7 @@ export function createFakeHost(options = {}) {
         return { sessionId: created.sessionId, agentPreset: created.agentPreset };
       }
       case 'session.history': {
+        tick();
         const session = sessions.get(payload.sessionId) ?? fail('session-not-found', '没有这个会话');
         return { events: session.events, hasMore: false };
       }
@@ -179,6 +185,7 @@ export function createFakeHost(options = {}) {
         push(session, 'user/message', { content: payload.content });
         session.pendingPolls = replyAfterPolls;
         session.startPolls = startAfterPolls;
+        session.turnStarted = false;
         session.reply = session === source ? '好的' : workerReply;
         return { accepted: true };
       }

--- a/test/migrate.test.mjs
+++ b/test/migrate.test.mjs
@@ -286,6 +286,25 @@ test('waitIdle：会话排队慢也不会被误判成已跑完', async () => {
   assert.equal(settled.started, true, '必须等到它真的跑起来再等它结束');
 });
 
+test('preview + execute：worker 轮询不应把 session.list 放大成全局扫描', async () => {
+  const host = createFakeHost({ replyAfterPolls: 30 });
+  const preview = await previewMigration(host.rpc, {
+    sessionId: host.sourceSessionId,
+    pollMs: 1,
+    workerTimeoutMs: 5_000,
+  });
+  await executeMigration(host.rpc, {
+    sessionId: host.sourceSessionId,
+    sourceSession: preview.sourceSession,
+    to: 'code',
+    summary: preview.summary,
+    lang: preview.lang,
+  });
+
+  const listCalls = host.state.calls.filter((call) => call.method === 'session.list');
+  assert.equal(listCalls.length, 1, '一次迁移只需读取一次源会话列表，worker 状态必须按会话查询');
+});
+
 test('档位推断不写死 provider/model', async () => {
   const host = createFakeHost();
   const pro = await resolveWorkerModel(host.rpc, host.sourceSessionId, 'pro');


### PR DESCRIPTION
## Summary

- replace compression-worker polling through global `session.list` with a bounded, session-specific `session.history` tail and a pre-prompt event watermark
- reuse the source session row across preview, migration, slash-command, and CLI paths instead of rescanning the global session list
- preserve the delayed-start guard by waiting for a newer `turn/start` and `turn/end`, without introducing a stale TTL cache

## Evidence

- RED: 30 worker polls produced 32 `session.list` calls
- GREEN: the same flow performs 1 source-list lookup, while delayed-start behavior remains correct
- `npm run verify`: 126/126 tests, generated `lib/` check, datasets check, and isolated package smoke all pass
- focused coverage: 89.43% lines overall; `src/migrate.ts` 94.43%

### Live official DSH acceptance

The current branch was packed and installed into a fresh isolated official `@deepseek-ai/dsh@0.1.1-rc.2` Web profile and exercised through the installed command registry with `deepseek-official/deepseek-v4-flash`:

- `/bridge --doctor`: 13/13
- source / preview / migrated target fact preservation: 4/4 / 4/4 / 4/4
- preview duration: 5,319 ms
- preview worker + target: 3,802 nominal tokens
- source model and `high` reasoning effort preserved on the target
- all 3 test sessions archived

The full RED/GREEN and live acceptance record is in `.github/tdd/issue-22-session-list-amplification.tdd.md`.

Closes #22
