### PR TITLE
docs: add dsh-TUI ecosystem link

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ npm run verify
 
 Community listings: [Awesome DSH Plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) · [Awesome DeepSeek Harness](https://github.com/Dominic789654/awesome-deepseek-harness)
 
+Ecosystem discovery: [dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI). Bridge remains a standard DSH plugin; TUI/std conformance is tracked separately.
+
 ## License
 
 MIT

--- a/README.zh.md
+++ b/README.zh.md
@@ -144,6 +144,8 @@ npm run verify
 
 社区收录：[Awesome DSH Plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) · [Awesome DeepSeek Harness](https://github.com/Dominic789654/awesome-deepseek-harness)
 
+生态发现入口：[dsh-TUI](https://github.com/ccch1mneyyy/dsh-TUI)。Bridge 仍按标准 DSH 插件安装；TUI/std 一致性适配另行跟踪。
+
 ## License
 
 MIT


### PR DESCRIPTION
Summary

- add the dsh-TUI ecosystem link required for marketplace submission
- keep the compatibility wording bounded: this does not claim dsh-std/TUI conformance
- mirror the note in the Chinese README

Verification

- git diff --check