### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Unreleased
 
+## 0.3.0 — 2026-08-26
+
 ### 官方 WebUI 原生迁移卡片
 
 - 同一个包新增可选 `dsh.client` half，在官方 `conversation.chat.commandview` slot 中渲染 `/bridge`。

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ dsh plugin --profile web add dsh-plugin-bridge
 Pinned GitHub fallback:
 
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.11
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.3.0
 ```
 
 Then type in the official WebUI:

--- a/README.zh.md
+++ b/README.zh.md
@@ -34,7 +34,7 @@ dsh plugin --profile web add dsh-plugin-bridge
 GitHub 固定版本备用路径：
 
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.11
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.3.0
 ```
 
 然后在官方 WebUI 输入：

--- a/docs/guide.zh.md
+++ b/docs/guide.zh.md
@@ -13,7 +13,7 @@ dsh plugin --profile web add dsh-plugin-bridge
 需要固定 GitHub tag 或 npm 暂时不可用时：
 
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.2.11
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.3.0
 ```
 
 发生了什么（不用手动干预）：

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-plugin-bridge",
-  "version": "0.2.11",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-plugin-bridge",
-      "version": "0.2.11",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-plugin-bridge",
-  "version": "0.2.11",
+  "version": "0.3.0",
   "description": "Previewable cross-preset session migration for DeepSeek Harness with bounded, fixed-schema handoffs",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## Summary

- release the official WebUI Preview / Text / Markdown handoff editor
- publish the React-free custom-UI client contract and secure preview-ID confirmation flow
- document idempotent retry, old-card replay, and ambiguous kickoff handling
- update pinned GitHub fallback install guidance to v0.3.0

## Validation

- `npm ci`
- `npm run verify` — 160/160, generated artifacts, datasets, and installed-tarball smoke
- `npm run release:check -- v0.3.0`
- PR #29 CI and CodeQL were green before merge

Publishing remains delegated to the existing GitHub Release OIDC Trusted Publishing workflow.