### PR TITLE
docs: add dshfind badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![node ≥22](https://img.shields.io/badge/node-%E2%89%A522-339933)](package.json)
 [![dsh rc.6 → 0.1.1-rc.2](https://img.shields.io/badge/dsh-rc.6%20%E2%86%92%200.1.1--rc.2-4c8dff)](https://github.com/deepseek-ai/deepseek-harness)
 [![Listed in Awesome DSH Plugin](https://img.shields.io/badge/listed_in-Awesome_DSH_Plugin-2ea44f)](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin)
+[![dshfind](https://dshfind.com/api/badge/Totoro-qaq/dsh-plugin-bridge?lang=en)](https://dshfind.com/en/plugins/Totoro-qaq/dsh-plugin-bridge?ref=badge)
 
 English | [中文](README.zh.md)
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -11,6 +11,7 @@
 [![node ≥22](https://img.shields.io/badge/node-%E2%89%A522-339933)](package.json)
 [![dsh rc.6 → 0.1.1-rc.2](https://img.shields.io/badge/dsh-rc.6%20%E2%86%92%200.1.1--rc.2-4c8dff)](https://github.com/deepseek-ai/deepseek-harness)
 [![收录于 Awesome DSH Plugin](https://img.shields.io/badge/%E5%B7%B2%E6%94%B6%E5%BD%95-Awesome_DSH_Plugin-2ea44f)](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin)
+[![dshfind](https://dshfind.com/api/badge/Totoro-qaq/dsh-plugin-bridge?lang=zh)](https://dshfind.com/zh/plugins/Totoro-qaq/dsh-plugin-bridge?ref=badge)
 
 [English](README.md) | 中文
 


### PR DESCRIPTION
## Summary

- add the compact dshfind score badge to the English README
- add the localized compact badge to the Chinese README
- keep the existing badge row and avoid the redundant downloads badge and large showcase card

## Validation

- both badge SVG endpoints return HTTP 200 with `image/svg+xml`
- both destination pages return HTTP 200
- GitHub README image/SVG audit passes for `README.md` and `README.zh.md`
- `git diff --check` passes

Docs-only change; no runtime behavior or package contents are modified.