### PR TITLE
docs: clarify preview draft lifetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ UIs that implement the official `conversation.chat.commandview` slot receive the
 /bridge code --go --file <path>
 ```
 
+Preview edits are temporary until migration is confirmed. Restarting the client or system may discard them; the source session remains untouched, and you can regenerate the preview.
+
 Uninstall with `dsh plugin --profile web remove dsh-plugin-bridge`, then restart `dsh web`.
 
 ## Why Bridge

--- a/README.zh.md
+++ b/README.zh.md
@@ -56,6 +56,8 @@ DSH rc.7 及以上会在官方 WebUI 原生卡片中渲染 `/bridge`。「文本
 /bridge code --go --file <路径>
 ```
 
+预览中的修改在确认迁移前只是临时草稿。重启客户端或系统可能使其丢失；源会话始终不受影响，重新运行预览即可生成新的草稿。
+
 卸载：`dsh plugin --profile web remove dsh-plugin-bridge`，然后重启 `dsh web`。
 
 ## 为什么是 Bridge


### PR DESCRIPTION
## Summary

- document that preview edits remain temporary until migration is confirmed
- clarify that a client or system restart may discard the draft
- reaffirm that the source session remains untouched and the preview can be regenerated

## Verification

- `git diff --check`
- compared both README files against current `main`; only the bilingual lifetime note was added