### PR TITLE
docs: verify DSH alpha.3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![ci](https://github.com/Totoro-qaq/dsh-plugin-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/Totoro-qaq/dsh-plugin-bridge/actions/workflows/ci.yml)
 [![license](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![node ≥22](https://img.shields.io/badge/node-%E2%89%A522-339933)](package.json)
-[![dsh rc.6 → 0.1.2-alpha.2](https://img.shields.io/badge/dsh-rc.6%20%E2%86%92%200.1.2--alpha.2-4c8dff)](https://github.com/deepseek-ai/deepseek-harness)
+[![dsh rc.6 → 0.1.2-alpha.3](https://img.shields.io/badge/dsh-rc.6%20%E2%86%92%200.1.2--alpha.3-4c8dff)](https://github.com/deepseek-ai/deepseek-harness)
 [![Listed in Awesome DSH Plugin](https://img.shields.io/badge/listed_in-Awesome_DSH_Plugin-2ea44f)](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin)
 [![dshfind](https://dshfind.com/api/badge/Totoro-qaq/dsh-plugin-bridge?lang=en)](https://dshfind.com/en/plugins/Totoro-qaq/dsh-plugin-bridge?ref=badge)
 
@@ -84,7 +84,7 @@ The release gate is intentionally small and reproducible; these are regression r
 | Confirm extra, paired nominal median | **+8.1%** vs `--continue` |
 | Summary worker share of clean acceptance components | **20.74% nominal** |
 | Native WebUI repeat gate (preview / target facts) | **3/3 · 3/3**, five facts each |
-| DSH 0.1.2-alpha.2 npm install / doctor / target | **clean · 13/13 · PTC paused** |
+| DSH 0.1.2 alpha.2 / alpha.3 installed WebUI | **13/13 · PTC paused · image → text fallback** |
 
 The token percentage varies widely with preset, response length, and cache state. The worker share is composition, not causal overhead versus no Bridge; the stable product claim is one additional confirmation request. Read the [design and evidence boundaries](docs/design.md), [full release report](reports/v0.2.3-e2e-report.md), and [vision report](reports/v0.2.6-rc11-vision-report.md).
 
@@ -117,7 +117,7 @@ The five sections are Goal, Current state, Key decisions and conventions, Key fi
 | 0.1.0-rc.6 | Yes | No | Narrow RPC contract and text compatibility tests |
 | 0.1.0-rc.7 / rc.8 | Yes | Contract-checked | Client-module/command-slot contract plus server fallback |
 | 0.1.1-rc.2 | Yes | Yes | Installed official WebUI: doctor 13/13, edit/confirm/auto-open, three-run repeat gate |
-| 0.1.2-alpha.2 | Yes | Yes | Official npm install: typed controllers 13/13, split-client build, edit/confirm/PTC auto-open, clean removal |
+| 0.1.2-alpha.2 / alpha.3 | Yes | Yes | Official npm install: typed controllers 13/13, edit/confirm/PTC auto-open; alpha.3 unresolved-image text fallback and clean removal |
 
 CI covers Node.js 22 and 24. Run `/bridge --doctor` after every Harness upgrade; it names missing required gateway methods instead of failing vaguely.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -9,7 +9,7 @@
 [![ci](https://github.com/Totoro-qaq/dsh-plugin-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/Totoro-qaq/dsh-plugin-bridge/actions/workflows/ci.yml)
 [![license](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![node ≥22](https://img.shields.io/badge/node-%E2%89%A522-339933)](package.json)
-[![dsh rc.6 → 0.1.2-alpha.2](https://img.shields.io/badge/dsh-rc.6%20%E2%86%92%200.1.2--alpha.2-4c8dff)](https://github.com/deepseek-ai/deepseek-harness)
+[![dsh rc.6 → 0.1.2-alpha.3](https://img.shields.io/badge/dsh-rc.6%20%E2%86%92%200.1.2--alpha.3-4c8dff)](https://github.com/deepseek-ai/deepseek-harness)
 [![收录于 Awesome DSH Plugin](https://img.shields.io/badge/%E5%B7%B2%E6%94%B6%E5%BD%95-Awesome_DSH_Plugin-2ea44f)](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin)
 [![dshfind](https://dshfind.com/api/badge/Totoro-qaq/dsh-plugin-bridge?lang=zh)](https://dshfind.com/zh/plugins/Totoro-qaq/dsh-plugin-bridge?ref=badge)
 
@@ -84,7 +84,7 @@ DSH rc.7 及以上会在官方 WebUI 原生卡片中渲染 `/bridge`。「文本
 | Confirm 相对 `--continue` 的 nominal 配对中位额外成本 | **+8.1%** |
 | 摘要 worker 在干净验收组件中的 nominal 占比 | **20.74%** |
 | 原生 WebUI 重复门禁（预览 / 目标事实） | **3/3 · 3/3**，每次五项 |
-| DSH 0.1.2-alpha.2 npm 安装 / doctor / 目标 | **干净 · 13/13 · PTC 已暂停** |
+| DSH 0.1.2 alpha.2 / alpha.3 官方 WebUI 实装 | **13/13 · PTC 已暂停 · 图片转文本降级** |
 
 token 百分比会随 preset、回复长度和缓存状态大幅波动；worker 占比是组成，不是相对“无 Bridge”的因果开销。稳定结论是默认确认多一个请求。边界和原始证据见[设计与证据说明](docs/design.md)、[完整 release report](reports/v0.2.3-e2e-report.md)和[视觉迁移报告](reports/v0.2.6-rc11-vision-report.md)。
 
@@ -117,7 +117,7 @@ token 百分比会随 preset、回复长度和缓存状态大幅波动；worker 
 | 0.1.0-rc.6 | 支持 | 不支持 | 窄 RPC 契约与文本兼容测试 |
 | 0.1.0-rc.7 / rc.8 | 支持 | 契约核对 | client module / command slot 契约与服务端回退 |
 | 0.1.1-rc.2 | 支持 | 支持 | 官方 WebUI 实装：doctor 13/13、编辑/确认/自动跳转、三次重复门禁 |
-| 0.1.2-alpha.2 | 支持 | 支持 | 官方 npm 实装：typed controllers 13/13、拆分 client 构建、编辑/确认/PTC 自动跳转、干净卸载 |
+| 0.1.2-alpha.2 / alpha.3 | 支持 | 支持 | 官方 npm 实装：typed controllers 13/13、编辑/确认/PTC 自动跳转；alpha.3 未解析图片转文本降级与干净卸载 |
 
 CI 覆盖 Node.js 22/24。每次升级 Harness 后先跑 `/bridge --doctor`；缺哪个必要网关方法会被直接点名。
 


### PR DESCRIPTION
## Summary

- extend the English and Chinese compatibility badge through DSH `0.1.2-alpha.3`
- record the installed alpha.3 WebUI gate in the evidence table
- update the compatibility matrix with typed-controller 13/13, PTC auto-open, paused goal, unresolved-image text fallback, and clean removal

## Runtime evidence

- fresh npm `@deepseek-ai/dsh@0.1.2-alpha.3`
- published `dsh-plugin-bridge@0.3.1`, no peer issues
- `/bridge --doctor`: `dsh-typed-controllers`, 13/13
- Preview/Text/Markdown editing and `code` to `ptc`
- two-image source: one associated verbatim response plus one truly unresolved image
- text-model target rejected the raw image with `session/attachment-invalid`; Bridge sent the text fallback and preserved the unresolved-image warning
- target auto-opened under PTC, retained all five fixed facts, and displayed a paused goal
- remove/restart left no dependency, bundle, package, client asset, Bridge DOM, or console-error residue

## Repository gate

- `npm run verify`: 167/167; build/typecheck, generated-lib drift, datasets, and 44-file package smoke passed

README-only: no package version or npm release change.
