### PR TITLE
chore: release v0.3.2

### DIFF
--- a/.github/tdd/dsh-alpha5-ordered-list-text-mode.tdd.md
+++ b/.github/tdd/dsh-alpha5-ordered-list-text-mode.tdd.md
@@ -49,7 +49,7 @@ The compatibility gate also required an existing titled alpha.3 profile to survi
 ## Boundaries
 
 - The runtime used isolated temporary profiles and a temporary credentials copy; both were deleted after verification.
-- This validates the branch tarball, not the currently published npm `0.3.1`; users need a subsequent release to receive the ordered-list fix.
+- This validates the branch tarball that became the `0.3.2` release candidate; npm `0.3.1` does not contain the ordered-list fix.
 - Alpha.4 was not tested as a standalone target; the verified upgrade path was alpha.3 directly to alpha.5.
 - No screenshot baseline was committed, so visual regression outside the exercised interaction states remains inconclusive.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 ## Unreleased
 
+## 0.3.2 — 2026-09-03
+
+### Native text editor
+
+- Accept flat ordered Markdown lists such as `1.` and `7)` in the five-section Text editor instead of forcing users back to raw Markdown.
+- Preserve each original list marker and continuation prefix when editing rows; newly added rows continue the final ordinal and delimiter.
+- Keep nested lists, mixed block structures, and other non-lossless Markdown fail-closed in the source editor.
+
+### DSH 0.1.2-alpha.5 compatibility
+
+- Upgrade a titled official alpha.3 profile in place to alpha.5 without losing its v4 projection-cache title.
+- Validate the packed client on the official alpha.5 WebUI: typed controllers 13/13, ordered-list Text/Markdown round trip, edited `ptc` target with paused goal, and automatic target opening.
+- Validate a Web-created `standard` source with an unresolved image falling back visibly on a text-only target, followed by residue-free removal and restart.
+
 ## 0.3.1 — 2026-08-31
 
 ### DSH 0.1.2-alpha.2 compatibility

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ dsh plugin --profile web add dsh-plugin-bridge
 Pinned GitHub fallback:
 
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.3.1
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.3.2
 ```
 
 Then type in the official WebUI:

--- a/README.zh.md
+++ b/README.zh.md
@@ -35,7 +35,7 @@ dsh plugin --profile web add dsh-plugin-bridge
 GitHub 固定版本备用路径：
 
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.3.1
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.3.2
 ```
 
 然后在官方 WebUI 输入：

--- a/docs/guide.zh.md
+++ b/docs/guide.zh.md
@@ -13,7 +13,7 @@ dsh plugin --profile web add dsh-plugin-bridge
 需要固定 GitHub tag 或 npm 暂时不可用时：
 
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.3.1
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.3.2
 ```
 
 发生了什么（不用手动干预）：

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-plugin-bridge",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-plugin-bridge",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-plugin-bridge",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Previewable cross-preset session migration for DeepSeek Harness with bounded, fixed-schema handoffs",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## Summary

- bump package and lockfile to `0.3.2`
- add the ordered-list Text editor fix and DSH alpha.5 installed-acceptance notes to the changelog
- update English, Chinese, and guide fallback examples to the `v0.3.2` tag
- retain the evidence boundary that npm `0.3.1` does not contain this fix

## Included fix

PR #41 added lossless Text-mode support for flat ordered lists, preserving original markers and continuation lines and continuing ordinals when rows are added.

## Release gate

- `npm ci`
- `npm run release:check -- v0.3.2`
- `npm run build` and clean generated-`lib` diff
- `npm run verify`: 170/170, datasets, and 44-file package smoke
- installed official DSH alpha.3 to alpha.5 upgrade and WebUI acceptance recorded in `.github/tdd/dsh-alpha5-ordered-list-text-mode.tdd.md`

After this PR merges, tag `v0.3.2` will be created through GitHub Release so the existing trusted-publishing workflow can publish npm.