### PR TITLE
chore: release v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Unreleased
 
+## 0.3.4 — 2026-09-10
+
 ### DSH 0.1.5-alpha.1
 
 - Extend the optional DSH peers to `^0.1.5-alpha.1` (DSH published no 0.1.4, and a caret prerelease range never matches the next prerelease minor), keep every older host range, and build against the exact 0.1.5-alpha.1 client SDK; the generated `lib/` is byte-identical to the 0.3.3 build.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ dsh plugin --profile web add dsh-plugin-bridge
 Pinned GitHub fallback:
 
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.3.3
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.3.4
 ```
 
 Then type in the official WebUI:
@@ -119,9 +119,9 @@ The five sections are Goal, Current state, Key decisions and conventions, Key fi
 | 0.1.1-rc.2 | Yes | Yes | Installed official WebUI: doctor 13/13, edit/confirm/auto-open, three-run repeat gate |
 | 0.1.2-alpha.2 / alpha.3 / alpha.5 | Yes | Yes | Official DSH npm hosts: typed controllers 13/13 and PTC auto-open; the alpha.5 gate installed the branch tarball, retained alpha.3 titles, edited ordered lists, fell back from unresolved image to text, and removed cleanly |
 | 0.1.2-rc.1 → 0.1.3-alpha.2 | Yes (Bridge 0.3.3+) | Yes (Bridge 0.3.3+) | Real npm-host upgrade, preserved v2 history/title, exact edited payload, PTC paused goal, image fallback and clean removal; see [acceptance report](reports/dsh-0.1.3-alpha.2-compat-2026-09-08.md) |
-| 0.1.5-alpha.1 | Unreleased candidate | Unreleased candidate | Official npm host with session format V3: tarball install, served native-card bundle, doctor 13/13 and preset listing on a V3 session; SDK type diff and V3 fold fixtures. Model-backed preview, migration and image fallback were not re-run; see [smoke report](reports/dsh-0.1.5-alpha.1-compat-2026-09-09.md) |
+| 0.1.5-alpha.1 | Yes (Bridge 0.3.4+) | Yes (Bridge 0.3.4+) | Official npm host with session format V3: tarball install, served native-card bundle, doctor 13/13 and preset listing on a V3 session; SDK type diff and V3 fold fixtures. Model-backed preview, migration and image fallback were not re-run; see [smoke report](reports/dsh-0.1.5-alpha.1-compat-2026-09-09.md) |
 
-The 0.1.5-alpha.1 compatibility changes are not included in published Bridge 0.3.3: DSH published no 0.1.4, and a caret prerelease range such as `^0.1.3-alpha.2` never matches the next prerelease minor, so the candidate adds `^0.1.5-alpha.1` and builds against that SDK with byte-identical `lib/` output. Session format V3 records the system prompt as a `system/message` surface node; Bridge folds only user, assistant and tool events, so prompt text never enters a handoff. Use Bridge 0.3.3 or later for DSH 0.1.3-alpha.2; Bridge 0.3.2 does not include those compatibility changes. The typed adapter reads the default 240-message history window with one fresh `inspect` call instead of four; it does not cache running state. `doctor` checks method availability, not end-to-end compatibility.
+Use Bridge 0.3.4 or later for DSH 0.1.5-alpha.1: DSH published no 0.1.4, and a caret prerelease range such as `^0.1.3-alpha.2` never matches the next prerelease minor, so 0.3.4 adds `^0.1.5-alpha.1` and builds against that SDK with byte-identical `lib/` output. Session format V3 records the system prompt as a `system/message` surface node; Bridge folds only user, assistant and tool events, so prompt text never enters a handoff. Use Bridge 0.3.3 or later for DSH 0.1.3-alpha.2; Bridge 0.3.2 does not include those compatibility changes. The typed adapter reads the default 240-message history window with one fresh `inspect` call instead of four; it does not cache running state. `doctor` checks method availability, not end-to-end compatibility.
 
 CI covers Node.js 22 and 24. Run `/bridge --doctor` after every Harness upgrade; it names missing required gateway methods instead of failing vaguely.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -35,7 +35,7 @@ dsh plugin --profile web add dsh-plugin-bridge
 GitHub 固定版本备用路径：
 
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.3.3
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.3.4
 ```
 
 然后在官方 WebUI 输入：
@@ -119,9 +119,9 @@ token 百分比会随 preset、回复长度和缓存状态大幅波动；worker 
 | 0.1.1-rc.2 | 支持 | 支持 | 官方 WebUI 实装：doctor 13/13、编辑/确认/自动跳转、三次重复门禁 |
 | 0.1.2-alpha.2 / alpha.3 / alpha.5 | 支持 | 支持 | 官方 DSH npm 宿主：typed controllers 13/13 与 PTC 自动跳转；alpha.5 门禁安装分支 tarball，保留 alpha.3 标题，编号列表可编辑，未解析图片降级为文本，卸载干净 |
 | 0.1.2-rc.1 → 0.1.3-alpha.2 | 支持（Bridge 0.3.3+） | 支持（Bridge 0.3.3+） | 官方 npm 宿主真实升级、v2 历史与标题保留、编辑内容逐字交接、PTC goal 暂停、图片回退及卸载；见[验收记录](reports/dsh-0.1.3-alpha.2-compat-2026-09-08.md) |
-| 0.1.5-alpha.1 | 未发布候选版 | 未发布候选版 | 官方 npm 宿主（会话格式 V3）：tarball 安装、原生卡片 bundle 已下发、V3 会话上 doctor 13/13 与预设列表；SDK 类型 diff 与 V3 折叠 fixture。未重跑需要模型的预览、迁移与图片回退；见[smoke 记录](reports/dsh-0.1.5-alpha.1-compat-2026-09-09.md) |
+| 0.1.5-alpha.1 | 支持（Bridge 0.3.4+） | 支持（Bridge 0.3.4+） | 官方 npm 宿主（会话格式 V3）：tarball 安装、原生卡片 bundle 已下发、V3 会话上 doctor 13/13 与预设列表；SDK 类型 diff 与 V3 折叠 fixture。未重跑需要模型的预览、迁移与图片回退；见[smoke 记录](reports/dsh-0.1.5-alpha.1-compat-2026-09-09.md) |
 
-0.1.5-alpha.1 的兼容改动尚未包含在已发布的 Bridge 0.3.3 中：DSH 没有发布 0.1.4，而 `^0.1.3-alpha.2` 这类 caret 预发布范围不会匹配下一个预发布 minor，所以候选版追加 `^0.1.5-alpha.1` 并基于该 SDK 构建，`lib/` 产物逐字节相同。会话格式 V3 把系统提示词记成 `system/message` surface node；Bridge 只折叠用户、助手和工具事件，提示词文本不会进入交接。DSH 0.1.3-alpha.2 请使用 Bridge 0.3.3 或更高版本；Bridge 0.3.2 不包含那些兼容改动。typed adapter 只调用一次 `inspect`，就能读取默认 240 条消息的历史窗口，原来需要四次；不会缓存运行状态。`doctor` 检查方法是否存在，不能代替完整迁移验收。
+DSH 0.1.5-alpha.1 请使用 Bridge 0.3.4 或更高版本：DSH 没有发布 0.1.4，而 `^0.1.3-alpha.2` 这类 caret 预发布范围不会匹配下一个预发布 minor，所以 0.3.4 追加 `^0.1.5-alpha.1` 并基于该 SDK 构建，`lib/` 产物逐字节相同。会话格式 V3 把系统提示词记成 `system/message` surface node；Bridge 只折叠用户、助手和工具事件，提示词文本不会进入交接。DSH 0.1.3-alpha.2 请使用 Bridge 0.3.3 或更高版本；Bridge 0.3.2 不包含那些兼容改动。typed adapter 只调用一次 `inspect`，就能读取默认 240 条消息的历史窗口，原来需要四次；不会缓存运行状态。`doctor` 检查方法是否存在，不能代替完整迁移验收。
 
 CI 覆盖 Node.js 22/24。每次升级 Harness 后先跑 `/bridge --doctor`；缺哪个必要网关方法会被直接点名。
 

--- a/docs/guide.zh.md
+++ b/docs/guide.zh.md
@@ -13,7 +13,7 @@ dsh plugin --profile web add dsh-plugin-bridge
 需要固定 GitHub tag 或 npm 暂时不可用时：
 
 ```bash
-dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.3.3
+dsh plugin --profile web add github:Totoro-qaq/dsh-plugin-bridge#v0.3.4
 ```
 
 发生了什么（不用手动干预）：

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-plugin-bridge",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-plugin-bridge",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
         "@deepseek-ai/schemastery": "^3.18.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-plugin-bridge",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Previewable cross-preset session migration for DeepSeek Harness with bounded, fixed-schema handoffs",
   "type": "module",
   "main": "lib/index.js",

--- a/reports/dsh-0.1.5-alpha.1-compat-2026-09-09.md
+++ b/reports/dsh-0.1.5-alpha.1-compat-2026-09-09.md
@@ -1,6 +1,6 @@
 # DSH 0.1.5-alpha.1 compatibility smoke
 
-Date: 2026-09-09 (Asia/Shanghai). **Bridge 0.3.4 candidate**, built from the `compat/dsh-0.1.5-alpha.1` branch on top of `f2d0fba` (v0.3.3). These results do not apply to the registry 0.3.3 package, whose peer ranges stop at `^0.1.3-alpha.2`.
+Date: 2026-09-09 (Asia/Shanghai). **Bridge 0.3.4 release smoke**. The runtime checks used the candidate built from the `compat/dsh-0.1.5-alpha.1` branch on top of `f2d0fba`, before its package version was bumped from 0.3.3 to 0.3.4. These results do not apply to the registry 0.3.3 package, whose peer ranges stop at `^0.1.3-alpha.2`.
 
 This is a smaller gate than the [0.1.3-alpha.2 acceptance](dsh-0.1.3-alpha.2-compat-2026-09-08.md): it proves install, load, host probing and the command path on the new host, and it audits the SDK contract by type diff. It does not repeat the model-backed preview, edit, migration or image-fallback runs; see [Not covered](#not-covered).
 


### PR DESCRIPTION
Release commit for 0.3.4, following the #43 → #44 pattern after #47 landed.

- `package.json` / `package-lock.json`: 0.3.3 → 0.3.4.
- `CHANGELOG.md`: date the DSH 0.1.5-alpha.1 entry as 0.3.4 — 2026-09-10.
- README (en/zh): compatibility row for 0.1.5-alpha.1 becomes "Yes (Bridge 0.3.4+)"; pinned GitHub fallback tag `#v0.3.3` → `#v0.3.4`; the "use Bridge 0.3.4 or later" wording.
- `docs/guide.zh.md`: pinned fallback tag.
- `reports/dsh-0.1.5-alpha.1-compat-2026-09-09.md`: header now names the 0.3.4 release smoke and the pre-bump candidate it ran on.

`npm run release:check -- v0.3.4` passes; `npm run verify` on Node 22.23.1: 176/176, no `lib/` drift, datasets, package smoke (46 files, `dsh-plugin-bridge@0.3.4`).

After merge: publish a GitHub release tagged `v0.3.4` (not a pre-release) so the trusted-publishing workflow pushes it to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
