### PR TITLE
docs: verify DSH 0.1.5-rc.1 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![ci](https://github.com/Totoro-qaq/dsh-plugin-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/Totoro-qaq/dsh-plugin-bridge/actions/workflows/ci.yml)
 [![license](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![node ≥22](https://img.shields.io/badge/node-%E2%89%A522-339933)](package.json)
-[![dsh 0.1.5-alpha.1](https://img.shields.io/badge/dsh-0.1.5--alpha.1-4c8dff)](https://github.com/deepseek-ai/deepseek-harness)
+[![dsh 0.1.5-rc.1](https://img.shields.io/badge/dsh-0.1.5--rc.1-4c8dff)](https://github.com/deepseek-ai/deepseek-harness)
 [![Listed in Awesome DSH Plugin](https://img.shields.io/badge/listed_in-Awesome_DSH_Plugin-2ea44f)](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin)
 [![dshfind](https://dshfind.com/api/badge/Totoro-qaq/dsh-plugin-bridge?lang=en)](https://dshfind.com/en/plugins/Totoro-qaq/dsh-plugin-bridge?ref=badge)
 
@@ -85,6 +85,7 @@ The release gate is intentionally small and reproducible; these are regression r
 | Summary worker share of clean acceptance components | **20.74% nominal** |
 | Native WebUI repeat gate (preview / target facts) | **3/3 · 3/3**, five facts each |
 | DSH 0.1.2 alpha.2 / alpha.3 / alpha.5 installed WebUI | **13/13 · ordered-list edit · PTC paused · image → text fallback** |
+| DSH 0.1.5-rc.1 installed WebUI, npm Bridge 0.3.4 | **13/13 · 3/3 migrations · edit reached target · PTC paused · raw image → vision target** |
 
 The token percentage varies widely with preset, response length, and cache state. The worker share is composition, not causal overhead versus no Bridge; the stable product claim is one additional confirmation request. Read the [design and evidence boundaries](docs/design.md), [full release report](reports/v0.2.3-e2e-report.md), and [vision report](reports/v0.2.6-rc11-vision-report.md).
 
@@ -120,8 +121,9 @@ The five sections are Goal, Current state, Key decisions and conventions, Key fi
 | 0.1.2-alpha.2 / alpha.3 / alpha.5 | Yes | Yes | Official DSH npm hosts: typed controllers 13/13 and PTC auto-open; the alpha.5 gate installed the branch tarball, retained alpha.3 titles, edited ordered lists, fell back from unresolved image to text, and removed cleanly |
 | 0.1.2-rc.1 → 0.1.3-alpha.2 | Yes (Bridge 0.3.3+) | Yes (Bridge 0.3.3+) | Real npm-host upgrade, preserved v2 history/title, exact edited payload, PTC paused goal, image fallback and clean removal; see [acceptance report](reports/dsh-0.1.3-alpha.2-compat-2026-09-08.md) |
 | 0.1.5-alpha.1 | Yes (Bridge 0.3.4+) | Yes (Bridge 0.3.4+) | Official npm host with session format V3: tarball install, served native-card bundle, doctor 13/13 and preset listing on a V3 session; SDK type diff and V3 fold fixtures. Model-backed preview, migration and image fallback were not re-run; see [smoke report](reports/dsh-0.1.5-alpha.1-compat-2026-09-09.md) |
+| 0.1.5-rc.1 | Yes (Bridge 0.3.4+) | Yes (Bridge 0.3.4+) | Official npm host with the published 0.3.4 unchanged: doctor 13/13, native card rendered, three model-backed migrations to PTC with an exact edited handoff and paused goal, and an unresolved image carried to the vision-capable default model; see [acceptance report](reports/dsh-0.1.5-rc.1-compat-2026-09-10.md) |
 
-Use Bridge 0.3.4 or later for DSH 0.1.5-alpha.1: DSH published no 0.1.4, and a caret prerelease range such as `^0.1.3-alpha.2` never matches the next prerelease minor, so 0.3.4 adds `^0.1.5-alpha.1` and builds against that SDK with byte-identical `lib/` output. Session format V3 records the system prompt as a `system/message` surface node; Bridge folds only user, assistant and tool events, so prompt text never enters a handoff. Use Bridge 0.3.3 or later for DSH 0.1.3-alpha.2; Bridge 0.3.2 does not include those compatibility changes. The typed adapter reads the default 240-message history window with one fresh `inspect` call instead of four; it does not cache running state. `doctor` checks method availability, not end-to-end compatibility.
+Use Bridge 0.3.4 or later for DSH 0.1.5-alpha.1: DSH published no 0.1.4, and a caret prerelease range such as `^0.1.3-alpha.2` never matches the next prerelease minor, so 0.3.4 adds `^0.1.5-alpha.1` and builds against that SDK with byte-identical `lib/` output. Session format V3 records the system prompt as a `system/message` surface node; Bridge folds only user, assistant and tool events, so prompt text never enters a handoff. Use Bridge 0.3.3 or later for DSH 0.1.3-alpha.2; Bridge 0.3.2 does not include those compatibility changes. The typed adapter reads the default 240-message history window with one fresh `inspect` call instead of four; it does not cache running state. `doctor` checks method availability, not end-to-end compatibility. The same `^0.1.5-alpha.1` range also matches 0.1.5-rc.1 and the 0.1.5 final, so rc.1 needs no new Bridge release.
 
 CI covers Node.js 22 and 24. Run `/bridge --doctor` after every Harness upgrade; it names missing required gateway methods instead of failing vaguely.
 
@@ -143,6 +145,7 @@ The server command stays the compatibility core. The same package now adds an op
 - [Vision migration report](reports/v0.2.6-rc11-vision-report.md)
 - [Native WebUI repeat acceptance](reports/native-workbench-2026-08-25.md)
 - [DSH 0.1.2-alpha.2 compatibility acceptance](reports/dsh-0.1.2-alpha.2-compat-2026-08-31.md)
+- [DSH 0.1.5-rc.1 compatibility acceptance](reports/dsh-0.1.5-rc.1-compat-2026-09-10.md)
 - [Historical compression benchmark](docs/benchmark.md)
 
 ## Development

--- a/README.zh.md
+++ b/README.zh.md
@@ -9,7 +9,7 @@
 [![ci](https://github.com/Totoro-qaq/dsh-plugin-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/Totoro-qaq/dsh-plugin-bridge/actions/workflows/ci.yml)
 [![license](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![node ≥22](https://img.shields.io/badge/node-%E2%89%A522-339933)](package.json)
-[![dsh 0.1.5-alpha.1](https://img.shields.io/badge/dsh-0.1.5--alpha.1-4c8dff)](https://github.com/deepseek-ai/deepseek-harness)
+[![dsh 0.1.5-rc.1](https://img.shields.io/badge/dsh-0.1.5--rc.1-4c8dff)](https://github.com/deepseek-ai/deepseek-harness)
 [![收录于 Awesome DSH Plugin](https://img.shields.io/badge/%E5%B7%B2%E6%94%B6%E5%BD%95-Awesome_DSH_Plugin-2ea44f)](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin)
 [![dshfind](https://dshfind.com/api/badge/Totoro-qaq/dsh-plugin-bridge?lang=zh)](https://dshfind.com/zh/plugins/Totoro-qaq/dsh-plugin-bridge?ref=badge)
 
@@ -85,6 +85,7 @@ DSH rc.7 及以上会在官方 WebUI 原生卡片中渲染 `/bridge`。「文本
 | 摘要 worker 在干净验收组件中的 nominal 占比 | **20.74%** |
 | 原生 WebUI 重复门禁（预览 / 目标事实） | **3/3 · 3/3**，每次五项 |
 | DSH 0.1.2 alpha.2 / alpha.3 / alpha.5 官方 WebUI 实装 | **13/13 · 编号列表编辑 · PTC 已暂停 · 图片转文本降级** |
+| DSH 0.1.5-rc.1 官方 WebUI 实装，npm Bridge 0.3.4 | **13/13 · 3/3 次迁移 · 编辑逐字送达 · PTC 已暂停 · 原图直达视觉目标** |
 
 token 百分比会随 preset、回复长度和缓存状态大幅波动；worker 占比是组成，不是相对“无 Bridge”的因果开销。稳定结论是默认确认多一个请求。边界和原始证据见[设计与证据说明](docs/design.md)、[完整 release report](reports/v0.2.3-e2e-report.md)和[视觉迁移报告](reports/v0.2.6-rc11-vision-report.md)。
 
@@ -120,8 +121,9 @@ token 百分比会随 preset、回复长度和缓存状态大幅波动；worker 
 | 0.1.2-alpha.2 / alpha.3 / alpha.5 | 支持 | 支持 | 官方 DSH npm 宿主：typed controllers 13/13 与 PTC 自动跳转；alpha.5 门禁安装分支 tarball，保留 alpha.3 标题，编号列表可编辑，未解析图片降级为文本，卸载干净 |
 | 0.1.2-rc.1 → 0.1.3-alpha.2 | 支持（Bridge 0.3.3+） | 支持（Bridge 0.3.3+） | 官方 npm 宿主真实升级、v2 历史与标题保留、编辑内容逐字交接、PTC goal 暂停、图片回退及卸载；见[验收记录](reports/dsh-0.1.3-alpha.2-compat-2026-09-08.md) |
 | 0.1.5-alpha.1 | 支持（Bridge 0.3.4+） | 支持（Bridge 0.3.4+） | 官方 npm 宿主（会话格式 V3）：tarball 安装、原生卡片 bundle 已下发、V3 会话上 doctor 13/13 与预设列表；SDK 类型 diff 与 V3 折叠 fixture。未重跑需要模型的预览、迁移与图片回退；见[smoke 记录](reports/dsh-0.1.5-alpha.1-compat-2026-09-09.md) |
+| 0.1.5-rc.1 | 支持（Bridge 0.3.4+） | 支持（Bridge 0.3.4+） | 官方 npm 宿主，已发布的 0.3.4 未改动：doctor 13/13，原生卡片实际渲染，三次真实模型迁移到 PTC，编辑内容逐字交接且 goal 保持暂停，未解析图片以原图交给支持图片的默认模型；见[验收记录](reports/dsh-0.1.5-rc.1-compat-2026-09-10.md) |
 
-DSH 0.1.5-alpha.1 请使用 Bridge 0.3.4 或更高版本：DSH 没有发布 0.1.4，而 `^0.1.3-alpha.2` 这类 caret 预发布范围不会匹配下一个预发布 minor，所以 0.3.4 追加 `^0.1.5-alpha.1` 并基于该 SDK 构建，`lib/` 产物逐字节相同。会话格式 V3 把系统提示词记成 `system/message` surface node；Bridge 只折叠用户、助手和工具事件，提示词文本不会进入交接。DSH 0.1.3-alpha.2 请使用 Bridge 0.3.3 或更高版本；Bridge 0.3.2 不包含那些兼容改动。typed adapter 只调用一次 `inspect`，就能读取默认 240 条消息的历史窗口，原来需要四次；不会缓存运行状态。`doctor` 检查方法是否存在，不能代替完整迁移验收。
+DSH 0.1.5-alpha.1 请使用 Bridge 0.3.4 或更高版本：DSH 没有发布 0.1.4，而 `^0.1.3-alpha.2` 这类 caret 预发布范围不会匹配下一个预发布 minor，所以 0.3.4 追加 `^0.1.5-alpha.1` 并基于该 SDK 构建，`lib/` 产物逐字节相同。会话格式 V3 把系统提示词记成 `system/message` surface node；Bridge 只折叠用户、助手和工具事件，提示词文本不会进入交接。DSH 0.1.3-alpha.2 请使用 Bridge 0.3.3 或更高版本；Bridge 0.3.2 不包含那些兼容改动。typed adapter 只调用一次 `inspect`，就能读取默认 240 条消息的历史窗口，原来需要四次；不会缓存运行状态。`doctor` 检查方法是否存在，不能代替完整迁移验收。 同一个 `^0.1.5-alpha.1` 范围也覆盖 0.1.5-rc.1 和之后的 0.1.5 正式版，所以 rc.1 不需要新发 Bridge。
 
 CI 覆盖 Node.js 22/24。每次升级 Harness 后先跑 `/bridge --doctor`；缺哪个必要网关方法会被直接点名。
 
@@ -143,6 +145,7 @@ CI 覆盖 Node.js 22/24。每次升级 Harness 后先跑 `/bridge --doctor`；�
 - [视觉迁移报告](reports/v0.2.6-rc11-vision-report.md)
 - [原生 WebUI 重复验收](reports/native-workbench-2026-08-25.md)
 - [DSH 0.1.2-alpha.2 兼容性验收](reports/dsh-0.1.2-alpha.2-compat-2026-08-31.md)
+- [DSH 0.1.5-rc.1 兼容性验收](reports/dsh-0.1.5-rc.1-compat-2026-09-10.md)
 - [历史压缩档位 benchmark](docs/benchmark.md)
 
 ## 开发验证

--- a/reports/dsh-0.1.5-rc.1-compat-2026-09-10.md
+++ b/reports/dsh-0.1.5-rc.1-compat-2026-09-10.md
@@ -1,0 +1,64 @@
+# DSH 0.1.5-rc.1 compatibility acceptance
+
+Date: 2026-09-10 (Asia/Shanghai). **Published Bridge 0.3.4 from npm**, unchanged. No Bridge code, dependency range or build changed for this run: the 0.3.4 peer term `^0.1.5-alpha.1` already matches `0.1.5-rc.1` and the future `0.1.5` final under npm semver. DSH made `0.1.5-rc.1` its npm `latest` on release day.
+
+## Environment
+
+- Official npm `@deepseek-ai/dsh@0.1.5-rc.1` in a scratch prefix (521 packages, Node 22.23.1, pnpm 11.22.0), isolated `DSH_HOME`, seeded scratch workspace. No user profile, session or credential file was read or modified.
+- `dsh plugin --profile web add dsh-plugin-bridge@0.3.4` from the registry: no peer warnings; Bridge joined the profile bundle layer after `@deepseek-ai/dsh-base` and `@deepseek-ai/dsh-web-app`.
+- The WebUI was driven by headless Google Chrome 152 through `playwright-core` with a throwaway browser profile. Unlike the in-app browser used for the 0.1.5-alpha.1 smoke, it held the `remote.mux` WebSocket, so the native card was rendered and inspected.
+- The repository owner entered their DeepSeek key in the isolated WebUI; it was stored only in that isolated `DSH_HOME` (`refs.DEEPSEEK_API_KEY`). Default model: `deepseek-flash` (DeepSeek-V41-Flash, image-capable), reasoning effort max. The Bridge summary worker used its `pro` tier (`deepseek-v4-pro`).
+- All Session content was synthetic.
+
+## Upstream contract
+
+Type declarations of every package Bridge pins or calls structurally were diffed between `0.1.5-alpha.1` and `0.1.5-rc.1`. Nothing Bridge uses changed:
+
+| Change | Effect on Bridge |
+|---|---|
+| Top-level `conversation` panel slot moved to `main.conversation` | None; Bridge registers `conversation.chat.commandview`, which is unchanged |
+| `forClosing(owner, sessionId)` file-mention hook; `DocumentFileIcon` replaced by `FileTypeIcon`; `CodeBlock`/`Menu` gained optional props | None; the card uses `MarkdownText` and `JsonTree` only |
+| Session controller gained `revealPath`/`workspaceDesktop` | None; the 13 methods Bridge probes are unchanged, `commands.execute(sessionId, line, attachments)` unchanged |
+| Session lifecycle: `SessionHandle`, per-process session lock | None observed; Bridge reads history through `inspect` and never opens logs |
+| Default model DeepSeek-V41-Flash accepts images | Changes which image path is common; see the image run below |
+| Pausing a goal aborts the active turn; only the user may resume | Bridge pauses before kickoff; the targets below all stayed paused with zero goal rounds |
+
+## Credential-free checks
+
+| Check | Result |
+|---|---|
+| `/bridge --doctor` | `dsh-typed-controllers · 13/13`, targets `ptc · minimal · cordis` |
+| Native card | Rendered for doctor, usage and error results; no page errors; no horizontal overflow at 1280 px |
+| `/bridge ptc` with no key configured | Failed closed with `worker-empty`; no target Session was created and the summary worker was archived |
+
+A Session that contains only command runs stays blank and keeps the empty-workspace hero view, so no command row or card appears there. One ordinary message first makes the Session non-blank.
+
+## Model-backed migration
+
+Three real migrations from a `standard` source to `ptc`, each on a fresh source Session:
+
+| Check | Run 1 | Run 2 | Image run |
+|---|---|---|---|
+| Source seed turn | 7 s | 6 s | Image admitted; turn stopped before any assistant analysis |
+| Preview facts (project code, PostgreSQL, port, planned `src/migration.ts`, MongoDB ban) | 5/5, 24 s | 5/5, 20 s | Project code kept; image reported as `未解析 1 条` |
+| Text mode | Five-section form, 5 fields | Five-section form, 5 fields | — |
+| Markdown edit of Next step | Reached target byte-exact | Reached target byte-exact; also visible back in Text mode | — |
+| Confirm | One target, auto-opened in PTC | One target, auto-opened in PTC | One target; confirmation says the unresolved original was carried to the vision target |
+| Target goal (projection cache) | `paused`, `maxGoalRounds 1`, `roundsStarted 0` | `paused`, `maxGoalRounds 1`, `roundsStarted 0`, objective contains the edit | Paused goal bar shown |
+| Target reply | Restated facts, ran no tools | Restated facts including the edited step as the next action, ran no tools | Read `IMG-4821` and the blue triangle from the carried image, restated, stopped |
+| Target turn usage | 10.8K tokens, cache 0% | 10.3K tokens, cache 83% | 23K tokens, cache 86%, 2 steps |
+| Page errors | 0 | 0 | 0 |
+
+Findings:
+
+- **Run 1's edit was a test artifact, not a product defect.** The edit line was labeled `EDIT-MARK-7731`. The kickoff tells the target to disregard anything "标记为已作废", and the target declined to treat the "MARK" line as confirmed, while still carrying it verbatim. Run 2 used a natural sentence and the target adopted it as the next step.
+- **Image kickoff costs one extra tool step in PTC.** The target already saw the attached image, then followed Bridge's note "请直接检查原图" by calling a read-only image tool before restating. No file was written and the goal stayed paused, but this is not the strict "restate and wait without tools" behavior, and it roughly doubled that turn's tokens. A wording change that says the image is already attached and needs no tool call is a candidate follow-up.
+- **Default-model image behavior changed.** With an image-capable default model, unresolved source images now normally travel as raw images to the target instead of falling back to text.
+
+## Not covered
+
+- The text-only image fallback was not re-run on rc.1; it requires switching the target to a text-only model. The 0.1.3-alpha.2 report remains the latest evidence for that path.
+- English UI, Node 24, `--go --continue`, and a `dsh plugin remove` plus restart cycle were not repeated.
+- Three runs are release evidence, not a statistical guarantee.
+
+The isolated install, profile, browser driver and screenshots stayed outside the repository.


### PR DESCRIPTION
Verification-only docs change, like #39. The published Bridge 0.3.4 already supports DSH 0.1.5-rc.1, which DSH made its npm `latest`: the `^0.1.5-alpha.1` peer term matches rc.1 and the 0.1.5 final. No code, dependency, build or version change, so no release is needed.

## Changes

- `reports/dsh-0.1.5-rc.1-compat-2026-09-10.md`: new acceptance report.
- README (en/zh): rc.1 badge, evidence row, compatibility row, a note that 0.3.4 already covers rc.1, and a documentation link.

## Evidence

Official npm `@deepseek-ai/dsh@0.1.5-rc.1` in an isolated `DSH_HOME`, `dsh-plugin-bridge@0.3.4` installed from the registry with no peer warnings. Driven by headless Chrome with a throwaway profile. The owner entered the key in the isolated WebUI.

| Check | Result |
|---|---|
| SDK type diff alpha.1 → rc.1 | Nothing Bridge uses changed; `conversation.chat.commandview` and `commands.execute` intact |
| `/bridge --doctor` | 13/13 |
| Native card | Rendered; 0 page errors |
| Preview without key | Fails closed (`worker-empty`), no target, worker archived |
| 3 migrations `standard` → `ptc` | Preview facts 5/5; Text mode 5 fields; Markdown edit reached target byte-exact; one target, auto-opened; goal `paused`, 0 rounds |
| Image run | Unresolved image carried as the original; target read it correctly |

## Follow-up candidate

On the image kickoff, the PTC target makes one read-only image tool call before restating, because the transfer note in `src/migrate.ts` says "请直接检查原图 / Inspect them directly". The goal stays paused and nothing is written, but that turn uses about 23K tokens instead of about 10K. A wording fix belongs in a separate code PR.

When the next release PR lands, add the new report to `package.json` `files`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
