### PR TITLE
fix: keep the image kickoff free of tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Unreleased
 
+### Image kickoff
+
+- Tell the target that unresolved source images are already attached to the kickoff message as images and must be checked visually without calling tools. On DSH 0.1.5-rc.1 a PTC target otherwise spent an extra read-image tool step before restating, roughly doubling that turn's tokens.
+
 ## 0.3.4 — 2026-09-10
 
 ### DSH 0.1.5-alpha.1

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -432,8 +432,8 @@ export async function executeMigration(input, options) {
             try {
                 const images = await readPromptImages(host, options.sessionId, unresolved.refs);
                 const transferNote = lang === 'en'
-                    ? 'Bridge transfer note: the unresolved source images listed above are attached to this kickoff. Inspect them directly; do not infer details that are not visible.'
-                    : 'Bridge 搬运说明：上文列出的未解析源图片已附在本次 kickoff 中。请直接检查原图，不得推断看不清的细节。';
+                    ? 'Bridge transfer note: the unresolved source images listed above are attached to this message as images, and you can already see them. Check them by looking at them; do not call any tool to read, open or locate them, and do not infer details that are not visible.'
+                    : 'Bridge 搬运说明：上文列出的未解析源图片已作为图片附在本条消息里，你现在就能看到。请直接看图核对，不要调用任何工具去读取、打开或查找这些图片，也不得推断看不清的细节。';
                 await host.sessions.prompt({
                     sessionId: created.sessionId,
                     mode: 'queue',

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -572,8 +572,8 @@ export async function executeMigration(input: BridgeHostInput, options: MigrateO
       try {
         const images = await readPromptImages(host, options.sessionId, unresolved.refs);
         const transferNote = lang === 'en'
-          ? 'Bridge transfer note: the unresolved source images listed above are attached to this kickoff. Inspect them directly; do not infer details that are not visible.'
-          : 'Bridge 搬运说明：上文列出的未解析源图片已附在本次 kickoff 中。请直接检查原图，不得推断看不清的细节。';
+          ? 'Bridge transfer note: the unresolved source images listed above are attached to this message as images, and you can already see them. Check them by looking at them; do not call any tool to read, open or locate them, and do not infer details that are not visible.'
+          : 'Bridge 搬运说明：上文列出的未解析源图片已作为图片附在本条消息里，你现在就能看到。请直接看图核对，不要调用任何工具去读取、打开或查找这些图片，也不得推断看不清的细节。';
         await host.sessions.prompt({
           sessionId: created.sessionId,
           mode: 'queue',

--- a/test/migrate.test.mjs
+++ b/test/migrate.test.mjs
@@ -157,7 +157,10 @@ test('migrate：未解析原图在视觉目标上自动随 kickoff 搬运', asyn
     (c) => c.method === 'session.prompt' && c.payload.sessionId === result.sessionId,
   );
   assert.equal(kickoff.payload.content[0].type, 'image');
-  assert.match(kickoff.payload.content.at(-1).text, /已附在本次 kickoff/);
+  const note = kickoff.payload.content.find((block) => block.type === 'text')?.text ?? '';
+  assert.match(note, /不要调用任何工具|do not call any tool/u, '原图已在消息里，目标不该再用工具读图');
+  assert.doesNotMatch(note, /请直接检查原图|Inspect them directly/u);
+  assert.match(kickoff.payload.content.at(-1).text, /已作为图片附在本条消息里/);
 });
 
 test('migrate：文本目标拒绝图片时无 token 请求地降级到文本 kickoff', async () => {


### PR DESCRIPTION
## Why

In the DSH 0.1.5-rc.1 acceptance (#49), the unresolved-image migration worked, but the PTC target made one read-only image tool call before restating. The target had already seen the attached image. It followed Bridge's transfer note, "请直接检查原图 / Inspect them directly", and treated it as a request to use a tool. That turned the restate-and-wait kickoff into two steps and about 23K tokens, where text kickoffs use about 10K.

## Change

- `src/migrate.ts`: the transfer note now says the images are already attached to this message as images and must be checked by looking at them, without calling any tool to read, open or locate them. Both languages changed; nothing else in the kickoff changed.
- `test/migrate.test.mjs`: the kickoff test pins the new wording and rejects the old one.
- `CHANGELOG.md`: Unreleased entry.
- `lib/`: regenerated.

`npm run verify` on Node 22.23.1: 176/176, no `lib/` drift, datasets, package smoke.

## Live check

I packed this branch and installed it into the isolated DSH 0.1.5-rc.1 profile with `dsh plugin add <tarball>`, then re-ran the image acceptance headlessly. The flow was the same both times: a `standard` source with an image, the turn stopped before any analysis, `/bridge ptc`, then Confirm migration. The target used the default model, DeepSeek-V41-Flash.

| | Published 0.3.4 | This branch |
|---|---|---|
| Kickoff turn | 1 turn, **2 steps**, 1 read-image tool call | 1 turn, **1 step**, no tool call |
| Target tokens | 23K | 10.6K |
| Reads the code from the carried image | Yes | Yes |
| Goal | Paused | Paused |
| Page errors | 0 | 0 |

The preview still reports the image as unresolved (`未解析 1 条`), and confirmation still says the original image went to the vision target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

