### PR TITLE
feat: default the summary worker to the conversation's model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 - Tell the target that unresolved source images are already attached to the kickoff message as images and must be checked visually without calling tools. On DSH 0.1.5-rc.1 a PTC target otherwise spent an extra read-image tool step before restating, roughly doubling that turn's tokens.
 
+### Summary worker model
+
+- Default `modelTier` is now `current`: the summary worker uses the source conversation's model instead of the provider's `pro`-like model. On DSH 0.1.5-rc.1 that is DeepSeek-V41-Flash, which matched V4-Pro on summary facts and on probing migrated `minimal` targets, with no wipeouts, at about half the summary time ([tier comparison](reports/worker-tier-rc1-2026-09-10.md)).
+- DSH releases before 0.1.5-rc.1 have no V4.1-Flash; set `DSH_BRIDGE_TIER=pro` or pass `--tier pro` to keep the previous behavior. `--tier`, `DSH_BRIDGE_TIER` and `workerModel` still override the default.
+
 ## 0.3.4 — 2026-09-10
 
 ### DSH 0.1.5-alpha.1

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ The five sections are Goal, Current state, Key decisions and conventions, Key fi
 
 Use Bridge 0.3.4 or later for DSH 0.1.5-alpha.1: DSH published no 0.1.4, and a caret prerelease range such as `^0.1.3-alpha.2` never matches the next prerelease minor, so 0.3.4 adds `^0.1.5-alpha.1` and builds against that SDK with byte-identical `lib/` output. Session format V3 records the system prompt as a `system/message` surface node; Bridge folds only user, assistant and tool events, so prompt text never enters a handoff. Use Bridge 0.3.3 or later for DSH 0.1.3-alpha.2; Bridge 0.3.2 does not include those compatibility changes. The typed adapter reads the default 240-message history window with one fresh `inspect` call instead of four; it does not cache running state. `doctor` checks method availability, not end-to-end compatibility. The same `^0.1.5-alpha.1` range also matches 0.1.5-rc.1 and the 0.1.5 final, so rc.1 needs no new Bridge release.
 
+Since 0.3.5 the summary worker follows the conversation's model by default (`modelTier: current`). On DSH 0.1.5-rc.1 that is V4.1-Flash, which matched V4-Pro in the [tier comparison](reports/worker-tier-rc1-2026-09-10.md) at about half the summary time. DSH releases before 0.1.5-rc.1 have no V4.1-Flash, so set `DSH_BRIDGE_TIER=pro` or pass `--tier pro` there.
+
 CI covers Node.js 22 and 24. Run `/bridge --doctor` after every Harness upgrade; it names missing required gateway methods instead of failing vaguely.
 
 Current limits:
@@ -146,6 +148,7 @@ The server command stays the compatibility core. The same package now adds an op
 - [Native WebUI repeat acceptance](reports/native-workbench-2026-08-25.md)
 - [DSH 0.1.2-alpha.2 compatibility acceptance](reports/dsh-0.1.2-alpha.2-compat-2026-08-31.md)
 - [DSH 0.1.5-rc.1 compatibility acceptance](reports/dsh-0.1.5-rc.1-compat-2026-09-10.md)
+- [Summary worker tier comparison on DSH 0.1.5-rc.1](reports/worker-tier-rc1-2026-09-10.md)
 - [Historical compression benchmark](docs/benchmark.md)
 
 ## Development

--- a/README.zh.md
+++ b/README.zh.md
@@ -125,6 +125,8 @@ token 百分比会随 preset、回复长度和缓存状态大幅波动；worker 
 
 DSH 0.1.5-alpha.1 请使用 Bridge 0.3.4 或更高版本：DSH 没有发布 0.1.4，而 `^0.1.3-alpha.2` 这类 caret 预发布范围不会匹配下一个预发布 minor，所以 0.3.4 追加 `^0.1.5-alpha.1` 并基于该 SDK 构建，`lib/` 产物逐字节相同。会话格式 V3 把系统提示词记成 `system/message` surface node；Bridge 只折叠用户、助手和工具事件，提示词文本不会进入交接。DSH 0.1.3-alpha.2 请使用 Bridge 0.3.3 或更高版本；Bridge 0.3.2 不包含那些兼容改动。typed adapter 只调用一次 `inspect`，就能读取默认 240 条消息的历史窗口，原来需要四次；不会缓存运行状态。`doctor` 检查方法是否存在，不能代替完整迁移验收。 同一个 `^0.1.5-alpha.1` 范围也覆盖 0.1.5-rc.1 和之后的 0.1.5 正式版，所以 rc.1 不需要新发 Bridge。
 
+0.3.5 起压缩工人默认跟随会话当前模型（`modelTier: current`）。在 DSH 0.1.5-rc.1 上这就是 V4.1-Flash，它在[档位对比](reports/worker-tier-rc1-2026-09-10.md)里与 V4-Pro 打平，摘要用时约减半。DSH 0.1.5-rc.1 之前的版本没有 V4.1-Flash，请设 `DSH_BRIDGE_TIER=pro` 或用 `--tier pro`。
+
 CI 覆盖 Node.js 22/24。每次升级 Harness 后先跑 `/bridge --doctor`；缺哪个必要网关方法会被直接点名。
 
 当前边界：
@@ -146,6 +148,7 @@ CI 覆盖 Node.js 22/24。每次升级 Harness 后先跑 `/bridge --doctor`；�
 - [原生 WebUI 重复验收](reports/native-workbench-2026-08-25.md)
 - [DSH 0.1.2-alpha.2 兼容性验收](reports/dsh-0.1.2-alpha.2-compat-2026-08-31.md)
 - [DSH 0.1.5-rc.1 兼容性验收](reports/dsh-0.1.5-rc.1-compat-2026-09-10.md)
+- [DSH 0.1.5-rc.1 压缩档位对比](reports/worker-tier-rc1-2026-09-10.md)
 - [历史压缩档位 benchmark](docs/benchmark.md)
 
 ## 开发验证

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -5,7 +5,8 @@
     - id: bridge
       name: dsh-plugin-bridge
       config:
-        modelTier: !!js process.env.DSH_BRIDGE_TIER ?? 'pro'
+        # 默认跟随源会话模型。DSH 0.1.5-rc.1 之前没有 V4.1-Flash，这类宿主建议设 pro。
+        modelTier: !!js process.env.DSH_BRIDGE_TIER ?? 'current'
         sourceCharBudget: !!js Number(process.env.DSH_BRIDGE_SOURCE_BUDGET ?? 60000)
         summaryCharBudget: !!js Number(process.env.DSH_BRIDGE_SUMMARY_BUDGET ?? 2400)
         # 上游 goal.create 的部署默认是 256 轮自主循环；交接只需要一轮。

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,5 +1,7 @@
 # Bridge 跨模式迁移 · 准确率实验报告
 
+> 0.3.5 更新：DSH 0.1.5-rc.1 的 V4.1-Flash 在同样的迁入 minimal 探针条件下与 V4-Pro 打平，默认档位已改为 `current`，见[档位对比](../reports/worker-tier-rc1-2026-09-10.md)。下文仍是 2026-08 基于 V4-Flash 的原始结论。
+
 日期：2026-08-17 ｜ 宿主：本地 `dsh web`（默认 127.0.0.1:3080） ｜ 模型：deepseek-v4-flash / deepseek-v4-pro
 脚本：`eval/run.mjs` ｜ 原始数据：`reports/benchmark-2026-08-17.raw.json`（含逐 run token 记账）
 

--- a/docs/guide.zh.md
+++ b/docs/guide.zh.md
@@ -114,7 +114,7 @@ dsh-bridge migrate --to code --summary-file <path>
 
 | 配置 | 环境变量 | 默认 | 说明 |
 |---|---|---|---|
-| `modelTier` | `DSH_BRIDGE_TIER` | `pro` | 压缩工人档位。实验结论：pro 与 flash 几乎同价（~2K tokens），但 flash 在 8 次里出现过 1 次全灭，离散度大一个数量级；**不要用 flash 迁 minimal**（三次两次全灭） |
+| `modelTier` | `DSH_BRIDGE_TIER` | `current` | 压缩工人档位，0.3.5 起默认跟随源会话当前模型。DSH 0.1.5-rc.1 的默认模型 V4.1-Flash 在迁移后探针测试里与 V4-Pro 打平（各 50/50、零全灭），摘要用时约减半，见[档位对比](../reports/worker-tier-rc1-2026-09-10.md)。DSH 0.1.5-rc.1 之前没有 V4.1-Flash，会话默认是 V4-Flash，它在 2026-08 的基准里迁入 minimal 时出现过全灭；这类宿主请设 `pro`。`flash` 取同 provider 目录里第一个 flash 类模型 |
 | `sourceCharBudget` | `DSH_BRIDGE_SOURCE_BUDGET` | `60000` | 取材总字符预算（≈30K tokens 输入） |
 | `summaryCharBudget` | `DSH_BRIDGE_SUMMARY_BUDGET` | `2400` | 摘要正文字符预算（≈900 tokens，注入侧成本上限） |
 | `goalRounds` | `DSH_BRIDGE_GOAL_ROUNDS` | `1` | 新会话的自主 goal 轮次上限，见下 |

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -38,7 +38,7 @@ const HELP = `dsh-bridge · 跨 preset 会话迁移
   --quiet               不打印进度
 
 preview / run：
-  --tier <flash|current|pro>   压缩档位（默认 pro）
+  --tier <flash|current|pro>   压缩档位（默认 current，跟随源会话模型）
   --provider <id> --model <id> 直接指定压缩模型，跳过档位推断
   --lang <zh|en|auto>          摘要语言（默认 auto，跟着会话内容走）
   --source-budget <n>          取材字符预算（默认 ${SOURCE_CHAR_BUDGET}）
@@ -109,7 +109,7 @@ function resolveSessionId(args) {
         + '如果你是在普通终端里手动跑，请用 --session <id> 指定（`dsh-bridge doctor` 会列出候选）。');
 }
 function tierOf(args) {
-    const value = str(args, 'tier') ?? 'pro';
+    const value = str(args, 'tier') ?? 'current';
     if (value !== 'flash' && value !== 'current' && value !== 'pro') {
         throw new UsageError(`--tier 只能是 flash / current / pro，收到 "${value}"`);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ export const inject = ['commands'];
 /** 命令是同步返回的，等压缩工人不能等太久。 */
 const DEFAULT_PREVIEW_TIMEOUT_MS = 180_000;
 export const Config = Schema.object({
-    modelTier: Schema.union(['flash', 'current', 'pro']).default('pro'),
+    modelTier: Schema.union(['flash', 'current', 'pro']).default('current'),
     sourceCharBudget: Schema.number().default(SOURCE_CHAR_BUDGET),
     summaryCharBudget: Schema.number().default(SUMMARY_CHAR_BUDGET),
     goalRounds: Schema.number().default(1),
@@ -50,7 +50,7 @@ function writeSummaryFile(sessionId, summary) {
 /** 把 Config 解析成命令层要的形状（Schema 已经填过默认值，这里只兜底）。 */
 export function commandConfigOf(config = {}) {
     return {
-        modelTier: config.modelTier ?? 'pro',
+        modelTier: config.modelTier ?? 'current',
         sourceCharBudget: config.sourceCharBudget ?? SOURCE_CHAR_BUDGET,
         summaryCharBudget: config.summaryCharBudget ?? SUMMARY_CHAR_BUDGET,
         goalRounds: config.goalRounds ?? 1,

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -191,7 +191,7 @@ export async function previewMigration(input, options) {
         throw new RpcError('bridge.preview', 'empty-source', '这个会话还没有可迁移的内容（取材为空）。直接开一个新会话更省事。');
     }
     const lang = options.lang && options.lang !== 'auto' ? options.lang : detectLang(source.text);
-    const tier = options.tier ?? 'pro';
+    const tier = options.tier ?? 'current';
     const route = await resolveWorkerModel(host, options.sessionId, tier, options);
     if (options.dryRun) {
         return { summary: '', source, lang, worker: { ...route }, capped: false, sourceSession };
@@ -345,9 +345,9 @@ export async function executeMigration(input, options) {
         ...where,
         agentPreset: options.to,
     });
-    // rc.2 的 session.selectModel 会同时保存 host 默认模型。预览 worker 通常
-    // 选择 pro 档位，因此如果这里依赖新会话默认值，目标会被 worker 悄悄改成
-    // pro，视觉源会话也会失去 VLM。显式复制源选择既保持用户模型意图，也让
+    // rc.2 的 session.selectModel 会同时保存 host 默认模型。预览 worker 可能
+    // 用了与源会话不同的档位模型（例如 --tier pro），因此如果这里依赖新会话
+    // 默认值，目标会被 worker 悄悄改成那个模型，视觉源会话也会失去 VLM。显式复制源选择既保持用户模型意图，也让
     // 未解析原图能在 kickoff 前通过目标模型的图片准入。
     let modelTransferred = false;
     if (sourceModel) {

--- a/reports/worker-tier-rc1-2026-09-10.md
+++ b/reports/worker-tier-rc1-2026-09-10.md
@@ -1,0 +1,49 @@
+# Summary worker tier on DSH 0.1.5-rc.1
+
+Date: 2026-09-10 (Asia/Shanghai). This report is why Bridge 0.3.5 changes the default `modelTier` from `pro` to `current`, so the summary worker uses the source conversation's own model.
+
+## Why the default was `pro`
+
+The [2026-08-17 benchmark](../docs/benchmark.md) compared `deepseek-v4-flash` with `deepseek-v4-pro` as the summary worker. The difference was not in the summaries: it came from probing the migrated target. Flash averaged 80% probe accuracy against 95% for pro, all of it from whole-run wipeouts. Two of three flash migrations into `minimal` lost every fact. `pro` became the default to remove that tail risk.
+
+DSH 0.1.5-rc.1 adds `deepseek-flash` (DeepSeek-V41-Flash) and makes it the default model for new sessions. The same catalog still offers `deepseek-v4-flash` and `deepseek-v4-pro`. No earlier DSH release offers V4.1-Flash; 0.1.1-rc.2 through 0.1.5-alpha.1 list only `deepseek-v4-flash`, `deepseek-v4-pro` and `deepseek-v4-flash-vision-exp`.
+
+## Environment
+
+- Official npm `@deepseek-ai/dsh@0.1.5-rc.1`, isolated `DSH_HOME`, published Bridge 0.3.4, Node 22.23.1.
+- WebUI driven by headless Google Chrome with a throwaway profile; the repository owner entered the DeepSeek key in the isolated WebUI.
+- Sources: all five themes from `datasets/test.json` and `datasets/validation.json`. Each source received the dataset's plant message and then a port change that voids the original port, so stale values can be detected. The workspace held only a README, so targets could not read the dataset.
+- Tiers resolved as `pro` → `deepseek-v4-pro`, `current` → `deepseek-flash` (the source model), `flash` → `deepseek-flash` (first flash-like id in the catalog). The worker receives provider and model only, so every worker ran at `high` reasoning effort even though the conversations used `max`.
+
+## Summary layer: previews
+
+24 previews, no target sessions. A fact counts when the summary contains the expected value, with the new port replacing the dataset's original port.
+
+| Tier | Model | Runs | Facts | Stale port | Median worker model time | Median output tokens |
+|---|---|---|---|---|---|---|
+| `pro` | deepseek-v4-pro | 10/10 | 50/50 | 0 | 24.4 s | 1,622 |
+| `current` | deepseek-flash | 10/10 | 50/50 | 0 | 12.7 s | 2,238 |
+| `flash` | deepseek-flash | 4/4 | 20/20 | 0 | 11.7 s | 1,963 |
+
+Every summary kept all five sections, stated the ban as a prohibition, copied the path exactly, and contained no unexpected numbers.
+
+## Probe layer: migrations into `minimal`
+
+This repeats the condition where the old flash failed. Each of the five themes was run twice. Within a source, `pro` and `current` each previewed and confirmed a migration into `minimal`, with alternating order between repetitions. The dataset's probe then asked the target five questions. Answers were scored from the saved replies, with 英文 accepted for `English` and Chinese for `中文`; the dataset's literal expectation otherwise marks the correct answer "提交信息使用英文" as a miss.
+
+| Tier | Model | Migrations | Probe facts | Without the language fact | Wipeouts (≤ 1/5) | Old port in answer |
+|---|---|---|---|---|---|---|
+| `pro` | deepseek-v4-pro | 10/10 | 50/50 | 40/40 | 0 | 0 |
+| `current` | deepseek-flash | 10/10 | 50/50 | 40/40 | 0 | 0 |
+
+Paired by source: 0 wins, 10 ties, 0 losses.
+
+## Reading the result
+
+- On DSH 0.1.5-rc.1, following the conversation model gives the same measured accuracy as `pro` at about half the summary time, and the old flash-into-minimal wipeout did not occur.
+- Both tiers scored 100%, so this set cannot show which model is better on harder material. Long or compacted sources were not tested for either tier.
+- Zero failures in ten runs per tier lowers, but does not exclude, a rare wipeout.
+- V4.1-Flash wrote more output tokens, up to 4,615 in one preview. Prices were not compared.
+- On DSH before 0.1.5-rc.1, `current` usually means `deepseek-v4-flash`, the model behind the old wipeouts. Users on those hosts should set `DSH_BRIDGE_TIER=pro` or pass `--tier pro`.
+
+Run artifacts, drivers and screenshots stayed outside the repository.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,7 +56,7 @@ const HELP = `dsh-bridge · 跨 preset 会话迁移
   --quiet               不打印进度
 
 preview / run：
-  --tier <flash|current|pro>   压缩档位（默认 pro）
+  --tier <flash|current|pro>   压缩档位（默认 current，跟随源会话模型）
   --provider <id> --model <id> 直接指定压缩模型，跳过档位推断
   --lang <zh|en|auto>          摘要语言（默认 auto，跟着会话内容走）
   --source-budget <n>          取材字符预算（默认 ${SOURCE_CHAR_BUDGET}）
@@ -130,7 +130,7 @@ function resolveSessionId(args: Args): string {
 }
 
 function tierOf(args: Args): ModelTier {
-  const value = str(args, 'tier') ?? 'pro';
+  const value = str(args, 'tier') ?? 'current';
   if (value !== 'flash' && value !== 'current' && value !== 'pro') {
     throw new UsageError(`--tier 只能是 flash / current / pro，收到 "${value}"`);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,7 +58,7 @@ export interface Config {
 }
 
 export const Config: Schema<Config> = Schema.object({
-  modelTier: Schema.union(['flash', 'current', 'pro']).default('pro'),
+  modelTier: Schema.union(['flash', 'current', 'pro']).default('current'),
   sourceCharBudget: Schema.number().default(SOURCE_CHAR_BUDGET),
   summaryCharBudget: Schema.number().default(SUMMARY_CHAR_BUDGET),
   goalRounds: Schema.number().default(1),
@@ -84,7 +84,7 @@ function writeSummaryFile(sessionId: string, summary: string): string | undefine
 /** 把 Config 解析成命令层要的形状（Schema 已经填过默认值，这里只兜底）。 */
 export function commandConfigOf(config: Config = {}) {
   return {
-    modelTier: config.modelTier ?? 'pro',
+    modelTier: config.modelTier ?? 'current',
     sourceCharBudget: config.sourceCharBudget ?? SOURCE_CHAR_BUDGET,
     summaryCharBudget: config.summaryCharBudget ?? SUMMARY_CHAR_BUDGET,
     goalRounds: config.goalRounds ?? 1,

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -283,7 +283,7 @@ export async function previewMigration(input: BridgeHostInput, options: PreviewO
   }
   const lang = options.lang && options.lang !== 'auto' ? options.lang : detectLang(source.text);
 
-  const tier = options.tier ?? 'pro';
+  const tier = options.tier ?? 'current';
   const route = await resolveWorkerModel(host, options.sessionId, tier, options);
   if (options.dryRun) {
     return { summary: '', source, lang, worker: { ...route }, capped: false, sourceSession };
@@ -488,9 +488,9 @@ export async function executeMigration(input: BridgeHostInput, options: MigrateO
     agentPreset: options.to,
   });
 
-  // rc.2 的 session.selectModel 会同时保存 host 默认模型。预览 worker 通常
-  // 选择 pro 档位，因此如果这里依赖新会话默认值，目标会被 worker 悄悄改成
-  // pro，视觉源会话也会失去 VLM。显式复制源选择既保持用户模型意图，也让
+  // rc.2 的 session.selectModel 会同时保存 host 默认模型。预览 worker 可能
+  // 用了与源会话不同的档位模型（例如 --tier pro），因此如果这里依赖新会话
+  // 默认值，目标会被 worker 悄悄改成那个模型，视觉源会话也会失去 VLM。显式复制源选择既保持用户模型意图，也让
   // 未解析原图能在 kickoff 前通过目标模型的图片准入。
   let modelTransferred = false;
   if (sourceModel) {

--- a/test/load.test.mjs
+++ b/test/load.test.mjs
@@ -73,7 +73,8 @@ test('BridgeHost 作为独立子路径对 adapter 作者可用', async () => {
 test('Config：空配置给默认值，且与压缩核心常量一致', async () => {
   const { SOURCE_CHAR_BUDGET, SUMMARY_CHAR_BUDGET } = await import('../lib/compression.js');
   const resolved = Config({});
-  assert.equal(resolved.modelTier, 'pro', '默认档位必须是 pro');
+  assert.equal(resolved.modelTier, 'current', '0.3.5 起默认档位跟随源会话模型');
+  assert.equal(commandConfigOf().modelTier, 'current');
   assert.equal(resolved.sourceCharBudget, SOURCE_CHAR_BUDGET);
   assert.equal(resolved.summaryCharBudget, SUMMARY_CHAR_BUDGET);
   assert.equal(resolved.goalRounds, 1, '上游 goal.create 默认 256 轮自主循环，交接只需要一轮');

--- a/test/migrate.test.mjs
+++ b/test/migrate.test.mjs
@@ -368,6 +368,15 @@ test('档位推断不写死 provider/model', async () => {
   assert.deepEqual([forced.provider, forced.model, forced.reason], ['x', 'y', 'configured']);
 });
 
+test('默认档位跟随源会话：不传 tier 时压缩工人用源会话当前模型', async () => {
+  const host = createFakeHost();
+  await previewMigration(host.rpc, { sessionId: host.sourceSessionId, ...fast });
+  const workerSelect = host.state.calls.find(
+    (call) => call.method === 'session.selectModel' && call.payload.sessionId !== host.sourceSessionId,
+  );
+  assert.equal(workerSelect?.payload.model, 'deepseek-v4', '默认不应再切到 pro 模型');
+});
+
 test('目录里没有对应档位的模型时退回会话当前模型', async () => {
   const host = createFakeHost({
     models: {


### PR DESCRIPTION
Merge after #49 and #50. This branch already contains both, so its own change is the last commit and the squash merge stays clean.

## Why

`pro` became the default after the 2026-08 benchmark. Probing migrated targets showed the old `deepseek-v4-flash` wiping out, including 2 of 3 migrations into `minimal`. DSH 0.1.5-rc.1 is now DSH's npm `latest`, and its default model is DeepSeek-V41-Flash. I re-ran that comparison on rc.1 ([report](reports/worker-tier-rc1-2026-09-10.md)):

| | `pro` → V4-Pro | `current` → V4.1-Flash |
|---|---|---|
| Summary facts, 10 previews each | 50/50 | 50/50 |
| Probe facts after migrating into `minimal`, 10 each | 50/50 | 50/50 |
| Wipeouts | 0 | 0 |
| Paired by source | 10 ties | 10 ties |
| Median worker model time | 24.4 s | 12.7 s |

## Change

- The default `modelTier` is now `current` in the config schema, default command config, core preview, CLI and profile patch. The worker follows the model the user already chose.
- `--tier pro`, `DSH_BRIDGE_TIER=pro` and `workerModel` still override it. Both READMEs, the guide and the changelog tell users on DSH before 0.1.5-rc.1 to set `pro`, since those hosts have no V4.1-Flash.
- New test: a preview without `--tier` gives the worker the source session's model. The load test now pins `current`.
- `docs/benchmark.md` now points to the new comparison.

`npm run verify` on Node 22.23.1: 177/177, no `lib/` drift, datasets, package smoke.

## Limits

Both tiers scored 100%, so this set cannot rank them on harder material. Long or compacted sources are untested for either tier. V4.1-Flash wrote more output tokens, and prices were not compared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
